### PR TITLE
[codex] Widen parkour stair steps

### DIFF
--- a/src/instinct_mj/tasks/parkour/config/parkour_env_cfg.py
+++ b/src/instinct_mj/tasks/parkour/config/parkour_env_cfg.py
@@ -94,7 +94,7 @@ ROUGH_TERRAINS_CFG = FiledTerrainGeneratorCfg(
         "pyramid_stairs": PerlinPyramidStairsTerrainCfg(
             proportion=0.15,
             step_height_range=(0.05, 0.23),
-            step_width=0.3,
+            step_width=0.35,
             platform_width=2.5,
             border_width=1.0,
             wall_prob=[0.3, 0.3, 0.3, 0.3],
@@ -121,7 +121,7 @@ ROUGH_TERRAINS_CFG = FiledTerrainGeneratorCfg(
         "pyramid_stairs_high": PerlinPyramidStairsTerrainCfg(
             proportion=0.10,
             step_height_range=(0.05, 0.45),
-            step_width=1.5,
+            step_width=1.54,
             platform_width=4.0,
             border_width=1.0,
             wall_prob=[0.3, 0.3, 0.3, 0.3],
@@ -148,7 +148,7 @@ ROUGH_TERRAINS_CFG = FiledTerrainGeneratorCfg(
         "pyramid_stairs_inv": PerlinInvertedPyramidStairsTerrainCfg(
             proportion=0.15,
             step_height_range=(0.05, 0.23),
-            step_width=0.3,
+            step_width=0.35,
             platform_width=2.5,
             border_width=1.0,
             wall_prob=[0.3, 0.3, 0.3, 0.3],
@@ -175,7 +175,7 @@ ROUGH_TERRAINS_CFG = FiledTerrainGeneratorCfg(
         "pyramid_stairs_inv_high": PerlinInvertedPyramidStairsTerrainCfg(
             proportion=0.10,
             step_height_range=(0.05, 0.45),
-            step_width=1.5,
+            step_width=1.54,
             platform_width=4.0,
             border_width=1.0,
             wall_prob=[0.3, 0.3, 0.3, 0.3],


### PR DESCRIPTION
## Summary
- widen parkour pyramid stair step widths while keeping `horizontal_scale=0.07` unchanged
- leave `square_gaps` at the original `(0.1, 0.7)` range

## Impact
- normal stairs quantize from 4 cells / 0.28 m to 5 cells / 0.35 m
- high stairs quantize from 21 cells / 1.47 m to 22 cells / 1.54 m

## Validation
- `python -m py_compile src/instinct_mj/tasks/parkour/config/parkour_env_cfg.py`