### PR TITLE
Update mjlab to 1.5.0 and align task configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ instinct_mj.egg-info/
 venv/
 .vscode/
 .pytest_cache/
+/tests/
 # Python cache files
 __pycache__/
 *.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "tyro>=1.0.1",
   "prettytable>=3.0.0",
   "PyYAML>=6.0",
-  "numpy>=1.24",
+  "numpy>=1.24,<2.5",
   "gymnasium>=0.29",
   "opencv-python>=4.8",
   "pyvista",
@@ -26,9 +26,9 @@ dependencies = [
   "pandas",
   "coacd",
   "warp-lang>=1.14.0",
-  "mujoco-warp>=3.8.0.3,~=3.8.0",
-  "mujoco~=3.8.0",
-  "mjlab==1.4.0",
+  "mujoco-warp>=3.10.0.1,~=3.10.0",
+  "mujoco~=3.10.0",
+  "mjlab==1.5.0",
   "instinct_rl",
 ]
 
@@ -52,7 +52,6 @@ environments = [
   "sys_platform == 'darwin' and platform_machine == 'arm64'",
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
-override-dependencies = ["mujoco>=3.8.0.dev0"]
 required-environments = [
   "sys_platform == 'darwin' and platform_machine == 'arm64'",
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
@@ -67,17 +66,10 @@ name = "nvidia"
 url = "https://pypi.nvidia.com/"
 explicit = true
 
-[[tool.uv.index]]
-name = "mujoco"
-url = "https://py.mujoco.org"
-explicit = true
-
 [tool.uv.sources]
 instinct_rl = { git = "https://github.com/project-instinct/instinct_rl.git" }
 mjlab = { path = "../mjlab", editable = true }
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
-mujoco = { index = "mujoco" }
-mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp", rev = "88b55fc2696960b927bc12584994bb8412b36558" }
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "onnxruntime",
   "pandas",
   "coacd",
+  "shapely>=2.0",
   "warp-lang>=1.14.0",
   "mujoco-warp>=3.10.0.1,~=3.10.0",
   "mujoco~=3.10.0",
@@ -41,11 +42,9 @@ instinct-depth-probe = "instinct_mj.scripts.depth_probe:main"
 instinct-amass-filter = "instinct_mj.scripts.amass_filter:entry_point"
 instinct-amass-visualize = "instinct_mj.scripts.amass_visualize:main"
 instinct-gmr-to-instinct = "instinct_mj.scripts.GMR_to_instinct:main"
+instinct-align-omomo-base = "instinct_mj.scripts.align_omomo_retargeted_base:entry_point"
 instinct-motion-metadata = "instinct_mj.scripts.motion_matched_metadata_generator:entry_point"
 instinct-phalp-to-amass = "instinct_mj.scripts.phalp_to_amass:entry_point"
-
-[project.entry-points."mjlab.tasks"]
-instinct_mj = "instinct_mj.tasks"
 
 [tool.uv]
 environments = [
@@ -76,6 +75,16 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+instinct_mj = [
+  "assets/resources/unitree_g1/*.xml",
+  "assets/resources/unitree_g1/xml/*.xml",
+  "assets/resources/unitree_g1/urdf/*.urdf",
+  "assets/resources/unitree_g1/meshes/*.STL",
+  "assets/resources/unitree_g1/meshes/*.stl",
+  "tasks/parkour/mjcf/*.xml",
+]
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/src/instinct_mj/assets/unitree_g1.py
+++ b/src/instinct_mj/assets/unitree_g1.py
@@ -137,8 +137,8 @@ DAMPING_7520_22 = 2.0 * DAMPING_RATIO * ARMATURE_7520_22 * NATURAL_FREQ
 DAMPING_4010 = 2.0 * DAMPING_RATIO * ARMATURE_4010 * NATURAL_FREQ
 
 
-# IsaacLab's DelayedPDActuator samples one command lag per episode (in
-# actuator.reset()) and holds it until the next reset. mjlab's DelayBuffer instead
+# The source delayed actuator samples one command lag per episode (in its reset)
+# and holds it until the next reset. mjlab's DelayBuffer instead
 # resamples a new lag every physics step when delay_update_period == 0. To recover the
 # per-episode-fixed-delay semantics we resample only on reset: pick an update period
 # larger than any episode's physics-step count so the lag is drawn once on the first

--- a/src/instinct_mj/envs/manager_based_rl_env.py
+++ b/src/instinct_mj/envs/manager_based_rl_env.py
@@ -4,7 +4,20 @@ from collections.abc import Sequence
 
 import torch
 from mjlab.envs import ManagerBasedRlEnv
-from mjlab.managers import RewardTermCfg
+from mjlab.managers import (
+    ActionManager,
+    CommandManager,
+    CurriculumManager,
+    EventManager,
+    MetricsManager,
+    NullCommandManager,
+    NullCurriculumManager,
+    NullMetricsManager,
+    NullRecorderManager,
+    ObservationManager,
+    RecorderManager,
+    TerminationManager,
+)
 from mjlab.sim import Simulation
 from mjlab.utils.logging import print_info
 from mjlab.viewer.debug_visualizer import DebugVisualizer
@@ -12,7 +25,7 @@ from mjlab.viewer.offscreen_renderer import OffscreenRenderer
 from prettytable import PrettyTable
 
 from instinct_mj.envs.scene import InstinctScene
-from instinct_mj.managers import MultiRewardCfg, MultiRewardManager
+from instinct_mj.managers import MultiRewardManager
 from instinct_mj.monitors import MonitorManager
 
 
@@ -85,43 +98,53 @@ class InstinctRlEnv(ManagerBasedRlEnv):
         self.setup_manager_visualizers()
 
     def load_managers(self) -> None:
-        # Route Instinct tasks through MultiRewardManager so reward logging matches
-        # InstinctLab conventions:
-        #   Episode_Reward/rewards_<term>/{max_episode_len_s,sum,timestep}
-        reward_group_cfg = self._as_multi_reward_cfg(self.cfg.rewards)
-        if reward_group_cfg is not None:
-            self.cfg.rewards = {}
+        """Load managers in mjlab order with InstinctLab multi-reward logging."""
+        # Event manager (required before everything else for domain randomization).
+        self.event_manager = EventManager(self.cfg.events, self)
+        print_info(f"[INFO] {self.event_manager}")
 
-        super().load_managers()
+        self.sim.expand_model_fields(self.event_manager.domain_randomization_fields)
 
-        # Replace parent reward manager with MultiRewardManager when requested.
-        if reward_group_cfg is not None:
-            self.cfg.rewards = reward_group_cfg
-            self.reward_manager = MultiRewardManager(self.cfg.rewards, self, scale_by_dt=self.cfg.scale_rewards_by_dt)
-            print_info(f"[INFO] {self.reward_manager}")
+        # Command manager must precede observations since observations may use commands.
+        if len(self.cfg.commands) > 0:
+            self.command_manager = CommandManager(self.cfg.commands, self)
+        else:
+            self.command_manager = NullCommandManager()
+        print_info(f"[INFO] {self.command_manager}")
+
+        self.action_manager = ActionManager(self.cfg.actions, self)
+        print_info(f"[INFO] {self.action_manager}")
+        self.observation_manager = ObservationManager(self.cfg.observations, self)
+        print_info(f"[INFO] {self.observation_manager}")
+
+        self.termination_manager = TerminationManager(self.cfg.terminations, self)
+        print_info(f"[INFO] {self.termination_manager}")
+        self.reward_manager = MultiRewardManager(
+            self.cfg.rewards,
+            self,
+            scale_by_dt=self.cfg.scale_rewards_by_dt,
+        )
+        print_info(f"[INFO] {self.reward_manager}")
+        if len(self.cfg.curriculum) > 0:
+            self.curriculum_manager = CurriculumManager(self.cfg.curriculum, self)
+        else:
+            self.curriculum_manager = NullCurriculumManager()
+        print_info(f"[INFO] {self.curriculum_manager}")
+        if len(self.cfg.metrics) > 0:
+            self.metrics_manager = MetricsManager(self.cfg.metrics, self)
+        else:
+            self.metrics_manager = NullMetricsManager()
+        print_info(f"[INFO] {self.metrics_manager}")
+        if len(self.cfg.recorders) > 0:
+            self.recorder_manager = RecorderManager(self.cfg.recorders, self)
+        else:
+            self.recorder_manager = NullRecorderManager()
+        print_info(f"[INFO] {self.recorder_manager}")
+
+        self._configure_gym_env_spaces()
 
         self.monitor_manager = MonitorManager(self.cfg.monitors, self)
         print_info(f"[INFO] Monitor Manager: {self.monitor_manager}")
-
-    @staticmethod
-    def _as_multi_reward_cfg(rewards_cfg):
-        """Convert reward config into a multi-reward group config when possible.
-
-        - Keep existing MultiRewardCfg as-is.
-        - For flat dict[str, RewardTermCfg], wrap into {"rewards": ...}.
-        - For grouped dicts (dict[str, dict[str, RewardTermCfg]]), keep as-is.
-        """
-        if isinstance(rewards_cfg, MultiRewardCfg):
-            return rewards_cfg
-        if isinstance(rewards_cfg, dict):
-            first_non_none = next(
-                (value for value in rewards_cfg.values() if value is not None),
-                None,
-            )
-            if first_non_none is None or isinstance(first_non_none, RewardTermCfg):
-                return {"rewards": rewards_cfg}
-            return rewards_cfg
-        return None
 
     def setup_manager_visualizers(self) -> None:
         super().setup_manager_visualizers()

--- a/src/instinct_mj/envs/manager_based_rl_env_cfg.py
+++ b/src/instinct_mj/envs/manager_based_rl_env_cfg.py
@@ -3,18 +3,25 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from mjlab.envs.manager_based_rl_env import ManagerBasedRlEnvCfg
+from mjlab.managers import RewardTermCfg
 from mjlab.viewer.viewer_config import ViewerConfig
 
 
-@dataclass
+@dataclass(kw_only=True)
 class InstinctLabRLEnvCfg(ManagerBasedRlEnvCfg):
     """Configuration for a reinforcement learning environment with the manager-based workflow."""
+
+    rewards: dict[str, dict[str, RewardTermCfg | str | None]] = field(default_factory=dict)
+    """Reward groups consumed directly by :class:`MultiRewardManager`."""
 
     viewer: ViewerConfig = field(default_factory=ViewerConfig)
     """Viewer Settings."""
 
+    run_name: str = ""
+    """Environment-specific suffix used for experiment log directories."""
+
     # monitor settings
-    monitors: object | None = None
+    monitors: dict = field(default_factory=dict)
     """Monitor Settings.
 
   Please refer to the `instinct_mj.monitors.MonitorManager` class for more details.

--- a/src/instinct_mj/envs/mdp/events/randomization.py
+++ b/src/instinct_mj/envs/mdp/events/randomization.py
@@ -30,6 +30,18 @@ _DR_ADD_CURRENT = dr.Operation(
     uses_defaults=False,
 )
 
+uniform_mass_scale_to_alpha = dr.Distribution(
+    name="uniform_mass_scale_to_alpha",
+    sample=lambda lo, hi, shape, device: 0.5 * torch.log(
+        math_utils.sample_uniform(
+            torch.exp(2.0 * lo),
+            torch.exp(2.0 * hi),
+            shape,
+            device=device,
+        )
+    ),
+)
+
 
 def _randomize_prop_by_op(
     data: torch.Tensor,

--- a/src/instinct_mj/managers/__init__.py
+++ b/src/instinct_mj/managers/__init__.py
@@ -1,4 +1,3 @@
 from mjlab.managers import *  # noqa: F401,F403
 
-from .manager_term_cfg import DummyRewardCfg, MultiRewardCfg
 from .reward_manager import MultiRewardManager

--- a/src/instinct_mj/managers/manager_term_cfg.py
+++ b/src/instinct_mj/managers/manager_term_cfg.py
@@ -1,25 +1,5 @@
-"""Configuration terms for different managers."""
+"""Configuration terms for different managers.
 
-from __future__ import annotations
-
-from collections.abc import Callable
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
-
-import torch
-
-
-@dataclass(kw_only=True)
-class MultiRewardCfg:
-    """Configuration for a reward group. Please inherit it if you want to define
-    your own reward group so that the manager can recognize it.
-    """
-
-    pass
-
-
-@dataclass(kw_only=True)
-class DummyRewardCfg:
-    """A placeholder for reward cfg."""
-
-    pass
+Reward groups use nested dictionaries directly, preserving grouped reward
+semantics without a class-style manager config or placeholder.
+"""

--- a/src/instinct_mj/managers/reward_manager.py
+++ b/src/instinct_mj/managers/reward_manager.py
@@ -12,8 +12,6 @@ from prettytable import PrettyTable
 if TYPE_CHECKING:
     from mjlab.envs import ManagerBasedRlEnv
 
-    from .manager_term_cfg import MultiRewardCfg
-
 
 class MultiRewardManager(RewardManager):
     """Manager to computing multiple groups of reward signals for a given world.
@@ -25,11 +23,17 @@ class MultiRewardManager(RewardManager):
     be in shape (num_envs, num_groups) where each column corresponds to the total reward.
     """
 
-    def __init__(self, cfg: MultiRewardCfg, env: ManagerBasedRlEnv, *, scale_by_dt: bool = True):
+    def __init__(
+        self,
+        cfg: dict[str, dict[str, RewardTermCfg | str | None]],
+        env: ManagerBasedRlEnv,
+        *,
+        scale_by_dt: bool = True,
+    ):
         """Initialize the reward manager.
 
         Args:
-            cfg: The configuration object or dictionary (``dict[str, RewardTermCfg]``).
+            cfg: Reward groups as ``dict[str, dict[str, RewardTermCfg]]``.
             env: The environment instance.
             scale_by_dt: Whether to scale the reward by the environment step dt.
         """
@@ -123,12 +127,13 @@ class MultiRewardManager(RewardManager):
         Returns:
             A dict or reward signal with shape (num_envs,) for each reward group.
         """
+        scale = dt if self._scale_by_dt else 1.0
         for group_name in self.__group_term_cfgs.keys():
             term_combine_method = self.__group_term_combine_methods.get(group_name, "sum")
             if term_combine_method == "sum":
                 self._reward_buf[group_name][:] = 0.0
             elif term_combine_method == "prod":
-                self._reward_buf[group_name][:] = dt
+                self._reward_buf[group_name][:] = scale
             else:
                 raise ValueError(f"Invalid term combine method: {term_combine_method}")
         # iterate over all the reward groups and terms
@@ -142,7 +147,7 @@ class MultiRewardManager(RewardManager):
                 value = term_cfg.func(self._env, **term_cfg.params) * term_cfg.weight
                 # update the reward buffer
                 if term_combine_method == "sum":
-                    self._reward_buf[group_name] += value * dt
+                    self._reward_buf[group_name] += value * scale
                 elif term_combine_method == "prod":
                     self._reward_buf[group_name] *= value
                 else:
@@ -150,7 +155,7 @@ class MultiRewardManager(RewardManager):
                 # update the termwise reward buffer
                 self._termwise_reward_buf[group_name][term_name] = value  # (num_envs,)
                 # update the episodic sum
-                self._episode_sums["_".join([group_name, term_name])] += value * dt
+                self._episode_sums["_".join([group_name, term_name])] += value * scale
         # return the reward buffer
         return self._reward_buf
 
@@ -198,22 +203,12 @@ class MultiRewardManager(RewardManager):
         self.__group_class_term_cfgs: dict[str, list[RewardTermCfg]] = dict()
         self.__group_term_combine_methods: dict[str, str] = dict()
 
-        # check if config is dict already
-        if isinstance(self.cfg, dict):
-            groups_cfg_items = self.cfg.items()
-        else:
-            groups_cfg_items = self.cfg.__dict__.items()
-        for group_name, group_cfg in groups_cfg_items:
+        for group_name, group_cfg in self.cfg.items():
             # check for non config
             if group_cfg is None:
                 continue
-            # check if config is dict already
-            if isinstance(group_cfg, dict):
-                group_cfg_items = group_cfg.items()
-            else:
-                group_cfg_items = group_cfg.__dict__.items()
             # iterate over all the terms
-            for term_name, term_cfg in group_cfg_items:
+            for term_name, term_cfg in group_cfg.items():
                 # check for non config
                 if term_cfg is None:
                     continue

--- a/src/instinct_mj/monitors/monitors.py
+++ b/src/instinct_mj/monitors/monitors.py
@@ -8,6 +8,7 @@ import torch
 from mjlab.actuator import BuiltinPdActuator, BuiltinPositionActuator, BuiltinVelocityActuator
 from mjlab.managers import SceneEntityCfg
 from mjlab.utils.lab_api import math as math_utils
+from mjlab.utils.lab_api.string import resolve_matching_names
 from torch.distributions import Multinomial
 
 from instinct_mj.motion_reference.utils import (
@@ -290,6 +291,44 @@ class ActuatorMonitorTerm(MonitorTerm):
                 "joint_vel": self._joint_vel.mean() * self.joint_vel_plot_scale,
                 "joint_power": self._joint_power.mean() * self.joint_power_plot_scale,
             }
+
+
+class ContactForceMonitorTerm(MonitorTerm):
+    """Monitors net contact forces on selected sensor bodies. Logs mean and max force norms per step."""
+
+    def __init__(self, cfg: MonitorTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        from mjlab.sensor import ContactSensor
+
+        self._contact_sensor: ContactSensor = env.scene[cfg.params["sensor_name"]]
+        self._body_ids, _ = resolve_matching_names(
+            cfg.params.get("body_names", ".*"),
+            self._contact_sensor.primary_names,
+            preserve_order=True,
+        )
+        self._force_mean = torch.zeros(env.num_envs, dtype=torch.float32, device=self.device)
+        self._force_max = torch.zeros(env.num_envs, dtype=torch.float32, device=self.device)
+
+    def update(self, dt: float):
+        net_forces = self._contact_sensor.data.force_history
+        # net_forces shape: (num_envs, num_bodies, history_length, 3)
+        force_norms = torch.norm(net_forces[:, self._body_ids], dim=-1)
+        # max over history, then stats over selected bodies
+        force_norms_max_hist = force_norms.max(dim=2).values  # (num_envs, num_selected_bodies)
+        self._force_mean[:] = force_norms_max_hist.mean(dim=-1)
+        self._force_max[:] = force_norms_max_hist.max(dim=-1).values
+
+    def reset_idx(self, env_ids: Sequence[int] | slice):
+        self._force_mean[env_ids] = 0.0
+        self._force_max[env_ids] = 0.0
+
+    def get_log(self, is_episode=False) -> dict[str, float | torch.Tensor]:
+        if is_episode:
+            return {}
+        return {
+            "force_mean": self._force_mean.mean(),
+            "force_max": self._force_max.max(),
+        }
 
 
 class BodyStatMonitorTerm(MonitorTerm):
@@ -982,3 +1021,74 @@ class ShadowingBasePosMonitorTerm(MonitorTerm):
             "reference_base_pos_y": self._reference_base_pos[:, 1].mean().item(),
             "reference_base_pos_z": self._reference_base_pos[:, 2].mean().item(),
         }
+
+
+class ShadowingGravityMonitorTerm(MonitorTerm):
+    """Monitors the projected gravity distance between the robot and the motion reference."""
+
+    def __init__(self, cfg: MonitorTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        if "robot_cfg" not in self.cfg.params:
+            self.cfg.params["robot_cfg"] = SceneEntityCfg("robot")
+        if "motion_reference_cfg" not in self.cfg.params:
+            self.cfg.params["motion_reference_cfg"] = SceneEntityCfg("motion_reference")
+
+        self._pg_diff = torch.zeros(self._env.num_envs, dtype=torch.float32, device=self.device)
+        self._pg_diff_currently = torch.zeros(self._env.num_envs, dtype=torch.float32, device=self.device)
+        self._pg_diff_max = torch.zeros(self._env.num_envs, dtype=torch.float32, device=self.device)
+        self._num_frames_should_reach = torch.zeros(self._env.num_envs, dtype=torch.int32, device=self.device)
+        self._all_ones = torch.ones(self._env.num_envs, dtype=torch.float32, device=self.device)
+
+    """
+    Operations
+    """
+
+    def update(self, dt: float):
+        motion_reference: MotionReferenceManager = self._env.scene[self.cfg.params["motion_reference_cfg"].name]
+
+        in_frame_mask = matching_reference_timing(
+            self._env,
+            self._all_ones,
+            motion_reference,
+            check_at_keyframe_threshold=self.cfg.params.get("check_at_keyframe_threshold", -1),  # type: ignore
+            multiply_by_frame_interval=False,
+        )
+
+        robot: Entity = self._env.scene[self.cfg.params["robot_cfg"].name]
+        rot = robot.data.root_link_quat_w
+        ref_rot = motion_reference.data.base_quat_w
+        ref_rot = ref_rot[motion_reference.ALL_INDICES, motion_reference.aiming_frame_idx]
+
+        pg = math_utils.quat_apply_inverse(rot, robot.data.gravity_vec_w)
+        ref_pg = math_utils.quat_apply_inverse(ref_rot, robot.data.gravity_vec_w)
+
+        if self.cfg.params.get("z_only", False):
+            diff = (pg[:, 2] - ref_pg[:, 2]).abs()
+        else:
+            diff = torch.norm(pg - ref_pg, dim=-1)
+
+        self._pg_diff += diff * in_frame_mask
+        self._pg_diff_currently = diff * in_frame_mask
+        self._pg_diff_max = torch.maximum(self._pg_diff_max, diff * in_frame_mask)
+        self._num_frames_should_reach += in_frame_mask.to(torch.int)
+
+    def reset_idx(self, env_ids: Sequence[int] | slice):
+        self._episodic_pg_diff = self._pg_diff[env_ids] / self._num_frames_should_reach[env_ids]
+        self._episodic_pg_diff_max = self._pg_diff_max[env_ids].clone()
+
+        self._pg_diff[env_ids] = 0.0
+        self._pg_diff_max[env_ids] = 0.0
+        self._num_frames_should_reach[env_ids] = 0
+
+    def get_log(self, is_episode=False) -> dict[str, float | torch.Tensor]:
+        if is_episode:
+            return {
+                "pg_dist_mean": self._episodic_pg_diff.nanmean().item(),
+                "pg_dist_max": self._episodic_pg_diff_max.max().item(),
+            }
+        else:
+            return {
+                "pg_dist_mean": (self._pg_diff / self._num_frames_should_reach).nanmean().item(),
+                "pg_dist_currently": self._pg_diff_currently.nanmean().item(),
+                "pg_dist_max": self._pg_diff_max.max().item(),
+            }

--- a/src/instinct_mj/scripts/align_omomo_retargeted_base.py
+++ b/src/instinct_mj/scripts/align_omomo_retargeted_base.py
@@ -1,0 +1,219 @@
+"""Align OMOMO retargeted motion base frames to InstinctMJ's G1 root body."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+from instinct_mj.assets.unitree_g1 import G1_MJCF_PATH
+
+
+SUPPORTED_ENDINGS = ("retargeted.npz", "retargetted.npz")
+
+
+def _quat_to_mat(quat: np.ndarray) -> np.ndarray:
+  mat = np.empty(9, dtype=np.float64)
+  mujoco.mju_quat2Mat(mat, quat.astype(np.float64, copy=False))
+  return mat.reshape(3, 3)
+
+
+def _mat_to_quat(mat: np.ndarray) -> np.ndarray:
+  quat = np.empty(4, dtype=np.float64)
+  mujoco.mju_mat2Quat(quat, mat.reshape(-1).astype(np.float64, copy=False))
+  return quat
+
+
+def _invert_pose(pos: np.ndarray, quat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+  rot_t = _quat_to_mat(quat).T
+  return -rot_t @ pos, _mat_to_quat(rot_t)
+
+
+def _compose_pose(
+  pos_a: np.ndarray,
+  quat_a: np.ndarray,
+  pos_b: np.ndarray,
+  quat_b: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+  rot_a = _quat_to_mat(quat_a)
+  rot_b = _quat_to_mat(quat_b)
+  return pos_a + rot_a @ pos_b, _mat_to_quat(rot_a @ rot_b)
+
+
+def _check_quat_norm(name: str, quat: np.ndarray, tolerance: float, path: Path) -> None:
+  if tolerance <= 0.0:
+    return
+  norms = np.linalg.norm(quat.reshape(-1, 4), axis=-1)
+  max_error = float(np.max(np.abs(norms - 1.0)))
+  if max_error > tolerance:
+    raise ValueError(
+      f"{path}: {name} quaternion norm error {max_error:.6g} exceeds tolerance {tolerance:.6g}."
+    )
+
+
+def _motion_files(input_path: Path) -> list[Path]:
+  if input_path.is_file():
+    return [input_path]
+  return sorted(path for path in input_path.rglob("*.npz") if path.name.endswith(SUPPORTED_ENDINGS))
+
+
+def _output_path(input_file: Path, input_root: Path, output_root: Path) -> Path:
+  if input_root.is_file():
+    return output_root
+  return output_root / input_file.relative_to(input_root)
+
+
+class BaseFrameAligner:
+  def __init__(self, model_path: str, src_frame: str, target_frame: str):
+    self.model_path = os.path.expanduser(model_path)
+    self.model = mujoco.MjModel.from_xml_path(self.model_path)
+    self.data = mujoco.MjData(self.model)
+    self.src_frame = src_frame
+    self.target_frame = target_frame
+    self.src_body_id = self._body_id(src_frame)
+    self.target_body_id = self._body_id(target_frame)
+    self.model_joint_names = [
+      mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+      for joint_id in range(self.model.njnt)
+    ]
+    self.actuated_joint_names = [name for name in self.model_joint_names if name != "floating_base_joint"]
+
+  def _body_id(self, name: str) -> int:
+    body_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, name)
+    if body_id < 0:
+      raise ValueError(f"Body '{name}' not found in {self.model_path}.")
+    return body_id
+
+  def _joint_pos_in_model_order(self, joint_names: list[str], joint_pos: np.ndarray) -> np.ndarray:
+    missing = [name for name in self.actuated_joint_names if name not in joint_names]
+    if missing:
+      raise ValueError(f"Missing joints required by the G1 model: {missing}")
+    return np.asarray(
+      [joint_pos[:, joint_names.index(name)] for name in self.actuated_joint_names],
+      dtype=np.float64,
+    ).T
+
+  def _relative_pose(self, joint_pos_frame: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    self.data.qpos[:] = 0.0
+    self.data.qpos[3] = 1.0
+    self.data.qpos[7:] = joint_pos_frame
+    mujoco.mj_forward(self.model, self.data)
+    src_pos = self.data.xpos[self.src_body_id].copy()
+    src_quat = self.data.xquat[self.src_body_id].copy()
+    target_pos = self.data.xpos[self.target_body_id].copy()
+    target_quat = self.data.xquat[self.target_body_id].copy()
+    return src_pos, src_quat, target_pos, target_quat
+
+  def convert_base_pose(
+    self,
+    joint_names: list[str],
+    joint_pos: np.ndarray,
+    src_pos_w: np.ndarray,
+    src_quat_w: np.ndarray,
+  ) -> tuple[np.ndarray, np.ndarray]:
+    if self.src_frame == self.target_frame:
+      return src_pos_w.copy(), src_quat_w.copy()
+
+    joint_pos_model = self._joint_pos_in_model_order(joint_names, joint_pos)
+    target_pos_w = np.empty_like(src_pos_w, dtype=np.float64)
+    target_quat_w = np.empty_like(src_quat_w, dtype=np.float64)
+    for frame_idx in range(joint_pos_model.shape[0]):
+      src_pos_b, src_quat_b, target_pos_b, target_quat_b = self._relative_pose(joint_pos_model[frame_idx])
+      inv_src_pos_b, inv_src_quat_b = _invert_pose(src_pos_b, src_quat_b)
+      root_pos_w, root_quat_w = _compose_pose(
+        src_pos_w[frame_idx],
+        src_quat_w[frame_idx],
+        inv_src_pos_b,
+        inv_src_quat_b,
+      )
+      target_pos_w[frame_idx], target_quat_w[frame_idx] = _compose_pose(
+        root_pos_w,
+        root_quat_w,
+        target_pos_b,
+        target_quat_b,
+      )
+    return target_pos_w.astype(src_pos_w.dtype), target_quat_w.astype(src_quat_w.dtype)
+
+
+def _load_joint_names(payload: np.lib.npyio.NpzFile, joint_pos: np.ndarray, path: Path) -> list[str]:
+  joint_names = payload["joint_names"].tolist()
+  if joint_names and joint_names[0] == "floating_base_joint" and len(joint_names) == joint_pos.shape[1] + 1:
+    joint_names = joint_names[1:]
+  if len(joint_names) != joint_pos.shape[1]:
+    raise ValueError(f"{path}: joint_names has {len(joint_names)} entries, joint_pos has {joint_pos.shape[1]} columns.")
+  return [str(name) for name in joint_names]
+
+
+def convert_file(
+  input_file: Path,
+  output_file: Path,
+  aligner: BaseFrameAligner,
+  quat_tolerance: float,
+  overwrite: bool,
+) -> None:
+  if output_file.exists() and not overwrite:
+    raise FileExistsError(f"{output_file} already exists. Pass --overwrite to replace it.")
+
+  payload = np.load(input_file, allow_pickle=True)
+  data = {key: payload[key] for key in payload.files}
+  joint_pos = np.asarray(payload["joint_pos"])
+  joint_names = _load_joint_names(payload, joint_pos, input_file)
+  base_pos_w = np.asarray(payload["base_pos_w"])
+  base_quat_w = np.asarray(payload["base_quat_w"])
+
+  _check_quat_norm("base_quat_w", base_quat_w, quat_tolerance, input_file)
+  if "object_quat_w" in payload:
+    _check_quat_norm("object_quat_w", np.asarray(payload["object_quat_w"]), quat_tolerance, input_file)
+
+  target_pos_w, target_quat_w = aligner.convert_base_pose(joint_names, joint_pos, base_pos_w, base_quat_w)
+  data["joint_names"] = np.asarray(joint_names, dtype=np.str_)
+  data["base_pos_w"] = target_pos_w
+  data["base_quat_w"] = target_quat_w
+
+  output_file.parent.mkdir(parents=True, exist_ok=True)
+  np.savez(output_file, **data)
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--input", required=True, help="Input retargeted .npz file or directory.")
+  parser.add_argument("--output", required=True, help="Output .npz file or directory.")
+  parser.add_argument("--model", default=G1_MJCF_PATH, help="InstinctMJ G1 MJCF path.")
+  parser.add_argument("--src-frame", default="pelvis", help="Frame currently stored in base_pos_w/base_quat_w.")
+  parser.add_argument("--target-frame", default="torso_link", help="Frame expected by InstinctMJ.")
+  parser.add_argument("--quat-norm-tolerance", type=float, default=1e-2)
+  parser.add_argument("--overwrite", action="store_true")
+  parsed = parser.parse_args() if args is None else args
+
+  input_path = Path(os.path.expanduser(parsed.input)).resolve()
+  output_path = Path(os.path.expanduser(parsed.output)).resolve()
+  files = _motion_files(input_path)
+  if not files:
+    raise ValueError(f"No supported retargeted npz files found under {input_path}.")
+  if input_path.is_file() and output_path.is_dir():
+    raise ValueError("--output must be a file path when --input is a file.")
+
+  aligner = BaseFrameAligner(parsed.model, parsed.src_frame, parsed.target_frame)
+  for input_file in files:
+    convert_file(
+      input_file=input_file,
+      output_file=_output_path(input_file, input_path, output_path),
+      aligner=aligner,
+      quat_tolerance=parsed.quat_norm_tolerance,
+      overwrite=parsed.overwrite,
+    )
+  print(
+    f"[align_omomo_retargeted_base] converted {len(files)} file(s): "
+    f"{parsed.src_frame} -> {parsed.target_frame}"
+  )
+
+
+def entry_point() -> None:
+  main()
+
+
+if __name__ == "__main__":
+  entry_point()

--- a/src/instinct_mj/scripts/hoi_npz_viser_playback.py
+++ b/src/instinct_mj/scripts/hoi_npz_viser_playback.py
@@ -1,0 +1,159 @@
+"""Direct Viser playback for retargeted OMOMO HOI npz files.
+
+This is a data visualization utility: it sets MuJoCo qpos directly from
+``base_pos_w``, ``base_quat_w`` and ``joint_pos``.  No RL policy or physics
+tracking is involved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import trimesh
+import viser
+
+from instinct_mj.assets.unitree_g1 import G1_MJCF_PATH
+from instinct_mj.tasks.shadowing.perceptive_hoi.config.g1.perceptive_shadowing_cfg import (
+    MESH_FILE_PATHS,
+    MESH_FILE_SCALES,
+)
+from mjlab.viewer.viser import ViserMujocoScene
+
+
+def _resolve_motion_file(path: Path) -> Path:
+    if path.is_file():
+        return path
+    files = sorted(path.glob("*.npz"))
+    if not files:
+        raise FileNotFoundError(f"No .npz files found under {path}")
+    return files[0]
+
+
+def _object_name_from_file(path: Path) -> str | None:
+    parts = path.name.split("_")
+    if len(parts) < 2:
+        return None
+    return parts[1]
+
+
+def _continuous_quat(quat: np.ndarray) -> np.ndarray:
+    quat = np.array(quat, dtype=np.float64, copy=True)
+    quat /= np.maximum(np.linalg.norm(quat, axis=-1, keepdims=True), 1e-12)
+    for frame_idx in range(1, len(quat)):
+        if np.dot(quat[frame_idx - 1], quat[frame_idx]) < 0.0:
+            quat[frame_idx] *= -1.0
+    return quat
+
+
+def _load_qpos(model: mujoco.MjModel, motion_file: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    motion = np.load(motion_file, allow_pickle=True)
+    framerate = float(motion["framerate"])
+    base_pos = np.asarray(motion["base_pos_w"], dtype=np.float64)
+    base_quat = _continuous_quat(np.asarray(motion["base_quat_w"], dtype=np.float64))
+    joint_pos = np.asarray(motion["joint_pos"], dtype=np.float64)
+    joint_names = motion["joint_names"] if isinstance(motion["joint_names"], list) else motion["joint_names"].tolist()
+
+    model_joint_names = [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        for joint_id in range(model.njnt)
+        if model.jnt_type[joint_id] != mujoco.mjtJoint.mjJNT_FREE
+    ]
+    joint_order = [joint_names.index(name) for name in model_joint_names]
+    joint_pos = joint_pos[:, joint_order]
+
+    qpos = np.zeros((len(base_pos), model.nq), dtype=np.float64)
+    qpos[:, :3] = base_pos
+    qpos[:, 3:7] = base_quat
+    qpos[:, 7:] = joint_pos
+
+    object_pos = np.asarray(motion["object_pos_w"], dtype=np.float64) if "object_pos_w" in motion else None
+    object_quat = _continuous_quat(np.asarray(motion["object_quat_w"], dtype=np.float64)) if "object_quat_w" in motion else None
+    return qpos, object_pos, object_quat, framerate
+
+
+def _add_object(server: viser.ViserServer, motion_file: Path):
+    object_name = _object_name_from_file(motion_file)
+    if object_name is None or object_name not in MESH_FILE_PATHS:
+        return None
+    mesh_path = Path(os.path.expanduser(MESH_FILE_PATHS[object_name]))
+    if not mesh_path.exists():
+        print(f"[WARN] Object mesh missing: {mesh_path}")
+        return None
+    mesh = trimesh.load(mesh_path, force="mesh")
+    scale = MESH_FILE_SCALES[object_name]
+    return server.scene.add_mesh_trimesh(
+        "/omomo_object",
+        mesh,
+        scale=scale,
+        wxyz=(1.0, 0.0, 0.0, 0.0),
+        position=(0.0, 0.0, 0.0),
+    )
+
+
+def run() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "motion_path",
+        nargs="?",
+        default="~/Datasets/OMOMO/retargeted_omniretarget_instinctmj_torso_v10_object_xy_align_foot_lock",
+        help="Retargeted OMOMO .npz file or directory.",
+    )
+    parser.add_argument("--model", default=G1_MJCF_PATH)
+    parser.add_argument("--port", type=int, default=8081)
+    parser.add_argument("--loop", action="store_true", default=True)
+    args = parser.parse_args()
+
+    motion_file = _resolve_motion_file(Path(os.path.expanduser(args.motion_path)))
+    model = mujoco.MjModel.from_xml_path(args.model)
+    data = mujoco.MjData(model)
+    qpos, object_pos, object_quat, framerate = _load_qpos(model, motion_file)
+
+    print(f"[INFO] Direct playback motion: {motion_file}")
+    print(f"[INFO] Frames: {len(qpos)}, framerate: {framerate}")
+
+    server = viser.ViserServer(port=args.port, label="OMOMO direct playback")
+    scene = ViserMujocoScene(server, model, num_envs=1)
+    scene.create_scene_gui(show_debug_viz_control=False)
+    object_handle = _add_object(server, motion_file)
+
+    with server.gui.add_folder("Playback"):
+        playing = server.gui.add_checkbox("Playing", initial_value=True)
+        frame_slider = server.gui.add_slider("Frame", min=0, max=len(qpos) - 1, step=1, initial_value=0)
+        speed = server.gui.add_slider("Speed", min=0.1, max=3.0, step=0.1, initial_value=1.0)
+
+    frame_idx = 0
+    last_time = time.time()
+    try:
+        while True:
+            now = time.time()
+            should_advance = playing.value and (now - last_time) >= (1.0 / (framerate * float(speed.value)))
+            if should_advance:
+                frame_idx = (frame_idx + 1) % len(qpos) if args.loop else min(frame_idx + 1, len(qpos) - 1)
+                frame_slider.value = frame_idx
+                last_time = now
+            elif not playing.value:
+                frame_idx = int(frame_slider.value)
+
+            data.qpos[:] = qpos[frame_idx]
+            mujoco.mj_forward(model, data)
+            scene.update_from_mjdata(data)
+
+            if object_handle is not None and object_pos is not None and object_quat is not None:
+                object_handle.position = object_pos[frame_idx]
+                object_handle.wxyz = object_quat[frame_idx]
+
+            if scene.needs_update:
+                scene.refresh_visualization()
+
+            time.sleep(0.005)
+    except KeyboardInterrupt:
+        server.stop()
+
+
+if __name__ == "__main__":
+    run()

--- a/src/instinct_mj/scripts/instinct_rl/train.py
+++ b/src/instinct_mj/scripts/instinct_rl/train.py
@@ -480,6 +480,8 @@ def launch_training(task_id: str, args: TrainConfig | None = None) -> None:
     args = args or TrainConfig.from_task(task_id)
     log_root_path = Path("logs") / "instinct_rl" / args.agent.experiment_name
     log_dir_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    if args.env.run_name:
+        log_dir_name += f"_{args.env.run_name}"
     if args.agent.run_name:
         log_dir_name += f"_{args.agent.run_name}"
     log_dir = log_root_path / log_dir_name

--- a/src/instinct_mj/tasks/locomotion/config/g1/agents/instinct_rl_ppo_cfg.py
+++ b/src/instinct_mj/tasks/locomotion/config/g1/agents/instinct_rl_ppo_cfg.py
@@ -56,6 +56,5 @@ class G1FlatPPORunnerCfg(InstinctRlOnPolicyRunnerCfg):
     load_run: object | None = None
 
     def __post_init__(self):
-        super().__post_init__()  # type: ignore
         self.resume = self.load_run is not None
         self.run_name = ""

--- a/src/instinct_mj/tasks/locomotion/config/g1/flat_env_cfg.py
+++ b/src/instinct_mj/tasks/locomotion/config/g1/flat_env_cfg.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import copy
 import math
+from dataclasses import dataclass, field
 
 import mjlab.envs.mdp as mdp
-from mjlab.envs import ManagerBasedRlEnvCfg
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers import CurriculumTermCfg as CurrTerm
 from mjlab.managers import EventTermCfg as Event
@@ -30,6 +30,7 @@ from instinct_mj.assets.unitree_g1 import (
     beyondmimic_action_scale,
     beyondmimic_g1_29dof_actuator_cfgs,
 )
+from instinct_mj.envs.manager_based_rl_env_cfg import InstinctLabRLEnvCfg
 
 G1_CFG = G1_29DOF_TORSOBASE_POPSICLE_CFG
 
@@ -39,49 +40,56 @@ G1_CFG = G1_29DOF_TORSOBASE_POPSICLE_CFG
 # ============================================================================
 
 
-def _scene_cfg(play: bool) -> SceneCfg:
-    robot_cfg = copy.deepcopy(G1_CFG)
-    robot_cfg.articulation.actuators = copy.deepcopy(beyondmimic_g1_29dof_actuator_cfgs)
-    feet_contact_forces = ContactSensorCfg(
-        name="feet_contact_forces",
-        primary=ContactMatch(
-            mode="body",
-            pattern=("left_ankle_roll_link", "right_ankle_roll_link"),
-            entity="robot",
-        ),
-        secondary=ContactMatch(mode="body", pattern="terrain"),
-        fields=("found", "force"),
-        reduce="maxforce",
-        track_air_time=True,
-        history_length=3,
-    )
-    base_contact_forces = ContactSensorCfg(
-        name="base_contact_forces",
-        primary=ContactMatch(
-            mode="body",
-            pattern=(
-                "torso_link",
-                ".*_shoulder_.*",
-                ".*_elbow_.*",
-                ".*_wrist_.*",
-                ".*_hip_.*",
-                ".*_knee_.*",
+@dataclass(kw_only=True)
+class G1LocomotionSceneCfg(SceneCfg):
+    """G1 locomotion scene in mjlab-native dataclass form."""
+
+    def __post_init__(self) -> None:
+        robot_cfg = copy.deepcopy(G1_CFG)
+        robot_cfg.articulation.actuators = copy.deepcopy(beyondmimic_g1_29dof_actuator_cfgs)
+        feet_contact_forces = ContactSensorCfg(
+            name="feet_contact_forces",
+            primary=ContactMatch(
+                mode="body",
+                pattern=("left_ankle_roll_link", "right_ankle_roll_link"),
+                entity="robot",
             ),
-            entity="robot",
-        ),
-        secondary=ContactMatch(mode="body", pattern="terrain"),
-        fields=("found", "force"),
-        reduce="maxforce",
-        track_air_time=False,
-        history_length=3,
-    )
-    return SceneCfg(
+            secondary=ContactMatch(mode="body", pattern="terrain"),
+            fields=("found", "force"),
+            reduce="maxforce",
+            track_air_time=True,
+            history_length=3,
+        )
+        base_contact_forces = ContactSensorCfg(
+            name="base_contact_forces",
+            primary=ContactMatch(
+                mode="body",
+                pattern=(
+                    "torso_link",
+                    ".*_shoulder_.*",
+                    ".*_elbow_.*",
+                    ".*_wrist_.*",
+                    ".*_hip_.*",
+                    ".*_knee_.*",
+                ),
+                entity="robot",
+            ),
+            secondary=ContactMatch(mode="body", pattern="terrain"),
+            fields=("found", "force"),
+            reduce="maxforce",
+            track_air_time=False,
+            history_length=3,
+        )
+        self.terrain = TerrainEntityCfg(terrain_type="plane")
+        self.entities = {"robot": robot_cfg}
+        self.sensors = (feet_contact_forces, base_contact_forces)
+        self.extent = 2.0
+
+
+def _scene_cfg(play: bool) -> G1LocomotionSceneCfg:
+    return G1LocomotionSceneCfg(
         num_envs=1 if play else 4096,
         env_spacing=2.5,
-        terrain=TerrainEntityCfg(terrain_type="plane"),
-        entities={"robot": robot_cfg},
-        sensors=(feet_contact_forces, base_contact_forces),
-        extent=2.0,
     )
 
 
@@ -357,55 +365,72 @@ def _curriculum_cfg() -> dict[str, CurrTerm]:
     return {}
 
 
-def instinct_g1_locomotion_flat_env_cfg(*, play: bool = False) -> ManagerBasedRlEnvCfg:
-    """Build locomotion config in mjlab-native manager dict style."""
-    cfg = ManagerBasedRlEnvCfg(
-        scene=_scene_cfg(play=play),
-        actions=_actions_cfg(),
-        commands=_commands_cfg(),
-        observations=_observations_cfg(),
-        rewards=_rewards_cfg(),
-        terminations=_terminations_cfg(),
-        events=_events_cfg(),
-        curriculum=_curriculum_cfg(),
-        viewer=ViewerConfig(
+@dataclass(kw_only=True)
+class G1LocomotionFlatEnvCfg(InstinctLabRLEnvCfg):
+    scene: G1LocomotionSceneCfg = field(default_factory=lambda: _scene_cfg(play=False))
+    actions: dict = field(default_factory=_actions_cfg)
+    commands: dict = field(default_factory=_commands_cfg)
+    observations: dict = field(default_factory=_observations_cfg)
+    rewards: dict = field(default_factory=lambda: {"rewards": _rewards_cfg()})
+    terminations: dict = field(default_factory=_terminations_cfg)
+    events: dict = field(default_factory=_events_cfg)
+    curriculum: dict = field(default_factory=_curriculum_cfg)
+    monitors: dict = field(default_factory=dict)
+    viewer: ViewerConfig = field(
+        default_factory=lambda: ViewerConfig(
             lookat=(0.0, 0.0, 0.0),
             distance=2.9,
             elevation=-10.0,
             azimuth=45.0,
             origin_type=ViewerConfig.OriginType.ASSET_ROOT,
             entity_name="robot",
-        ),
-        sim=SimulationCfg(
+        )
+    )
+    sim: SimulationCfg = field(
+        default_factory=lambda: SimulationCfg(
             mujoco=MujocoCfg(
                 timestep=0.005,
                 solver="newton",
                 iterations=10,
                 ls_iterations=20,
-                ccd_iterations=500 if not play else 50,
+                ccd_iterations=500,
             ),
-        ),
-        decimation=4,
-        episode_length_s=20.0,
+        )
     )
-    cfg.monitors = {}
-    cfg.sim.njmax = 300
-    joint_pos_action: JointPositionActionCfg = cfg.actions["joint_pos"]
-    joint_pos_action.scale = copy.deepcopy(beyondmimic_action_scale)
-    feet_air_time = cfg.rewards.get("feet_air_time")
-    stand_still = cfg.rewards.get("stand_still")
-    action_rate_l2 = cfg.rewards.get("action_rate_l2")
-    joint_deviation_knee = cfg.rewards.get("joint_deviation_knee")
-    cfg.run_name = "".join(
-        [
-            "G1Flat",
-            f"_feetAirTime{feet_air_time.weight:.2f}" if feet_air_time is not None else "",
-            f"_standStill{-stand_still.weight:.2f}" if stand_still is not None else "",
-            f"_actionRate{-action_rate_l2.weight:.2f}" if action_rate_l2 is not None else "",
-            (f"_jointDeviationKnee{-joint_deviation_knee.weight:.2f}" if joint_deviation_knee is not None else ""),
-        ]
-    )
+    decimation: int = 4
+    episode_length_s: float = 20.0
+
+    def __post_init__(self) -> None:
+        # All managers are already dicts, no conversion needed!
+        self.sim.njmax = 300
+        joint_pos_action: JointPositionActionCfg = self.actions["joint_pos"]
+        joint_pos_action.scale = copy.deepcopy(beyondmimic_action_scale)
+        reward_terms = self.rewards["rewards"]
+        feet_air_time = reward_terms.get("feet_air_time")
+        stand_still = reward_terms.get("stand_still")
+        action_rate_l2 = reward_terms.get("action_rate_l2")
+        joint_deviation_knee = reward_terms.get("joint_deviation_knee")
+        self.run_name = "".join(
+            [
+                "G1Flat",
+                f"_feetAirTime{feet_air_time.weight:.2f}" if feet_air_time is not None else "",
+                f"_standStill{-stand_still.weight:.2f}" if stand_still is not None else "",
+                f"_actionRate{-action_rate_l2.weight:.2f}" if action_rate_l2 is not None else "",
+                (
+                    f"_jointDeviationKnee{-joint_deviation_knee.weight:.2f}"
+                    if joint_deviation_knee is not None
+                    else ""
+                ),
+            ]
+        )
+
+
+def instinct_g1_locomotion_flat_env_cfg(*, play: bool = False) -> G1LocomotionFlatEnvCfg:
+    """Build locomotion config in mjlab-native manager dict style."""
+    cfg = G1LocomotionFlatEnvCfg()
     if play:
+        cfg.scene = _scene_cfg(play=True)
+        cfg.sim.mujoco.ccd_iterations = 50
         base_velocity_cmd: UniformVelocityCommandCfg = cfg.commands["base_velocity"]
         base_velocity_cmd.resampling_time_range = (2.0, 2.0)
         cfg.events["base_external_force_torque"] = None

--- a/src/instinct_mj/tasks/locomotion/config/g1/rl_cfgs.py
+++ b/src/instinct_mj/tasks/locomotion/config/g1/rl_cfgs.py
@@ -1,44 +1,8 @@
 """Instinct-RL configs for G1 locomotion tasks."""
 
-from __future__ import annotations
-
-from instinct_mj.rl import InstinctRlActorCriticCfg, InstinctRlOnPolicyRunnerCfg, InstinctRlPpoAlgorithmCfg
-from instinct_mj.tasks.config.rl_utils import default_policy_critic_normalizers
+from instinct_mj.rl import InstinctRlOnPolicyRunnerCfg
+from instinct_mj.tasks.locomotion.config.g1.agents.instinct_rl_ppo_cfg import G1FlatPPORunnerCfg
 
 
 def g1_locomotion_instinct_rl_cfg() -> InstinctRlOnPolicyRunnerCfg:
-    return InstinctRlOnPolicyRunnerCfg(
-        policy=InstinctRlActorCriticCfg(
-            class_name="ActorCritic",
-            init_noise_std=1.0,
-            actor_hidden_dims=(256, 128, 128),
-            critic_hidden_dims=(256, 128, 128),
-            activation="elu",
-        ),
-        algorithm=InstinctRlPpoAlgorithmCfg(
-            class_name="PPO",
-            value_loss_coef=1.0,
-            use_clipped_value_loss=True,
-            clip_param=0.2,
-            entropy_coef=0.008,
-            num_learning_epochs=5,
-            num_mini_batches=4,
-            learning_rate=1.0e-3,
-            optimizer_class_name="AdamW",
-            schedule="adaptive",
-            gamma=0.99,
-            lam=0.95,
-            desired_kl=0.01,
-            max_grad_norm=1.0,
-            clip_min_std=1.0e-12,
-        ),
-        normalizers=default_policy_critic_normalizers(),
-        num_steps_per_env=24,
-        max_iterations=5_000,
-        save_interval=1_000,
-        log_interval=10,
-        experiment_name="g1_locomotion_flat",
-        run_name="",
-        policy_observation_group="policy",
-        critic_observation_group="critic",
-    )
+    return G1FlatPPORunnerCfg()

--- a/src/instinct_mj/tasks/locomotion/mdp/events.py
+++ b/src/instinct_mj/tasks/locomotion/mdp/events.py
@@ -7,30 +7,99 @@
 
 from __future__ import annotations
 
+import math
 from typing import Literal
 
 import torch
 from mjlab.entity import Entity
 from mjlab.envs.mdp import dr
 from mjlab.managers import SceneEntityCfg
+from mjlab.managers.event_manager import RecomputeLevel, requires_model_fields
 from mjlab.utils.lab_api.math import sample_uniform
 
+from instinct_mj.envs.mdp.events.randomization import uniform_mass_scale_to_alpha
 
+
+@requires_model_fields(
+    "body_mass",
+    "body_ipos",
+    "body_inertia",
+    "body_iquat",
+    recompute=RecomputeLevel.set_const,
+)
 def randomize_rigid_body_mass(
     env,
     env_ids: torch.Tensor | None,
     asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
     mass_distribution_params: tuple[float, float] = (-0.5, 0.5),
     operation: Literal["add", "scale", "abs"] = "add",
+    distribution: str = "uniform",
 ) -> None:
-    """Randomize rigid-body mass."""
-    dr.body_mass(
-        env=env,
-        env_ids=env_ids,
-        ranges=mass_distribution_params,
-        operation=operation,
-        asset_cfg=asset_cfg,
+    """Randomize rigid-body pseudo-inertia."""
+    pseudo_inertia_distribution = uniform_mass_scale_to_alpha if distribution == "uniform" else distribution
+    if operation == "scale":
+        alpha_range = _mass_scale_to_alpha_range(mass_distribution_params)
+        dr.pseudo_inertia(
+            env=env,
+            env_ids=env_ids,
+            alpha_range=alpha_range,
+            distribution=pseudo_inertia_distribution,
+            asset_cfg=asset_cfg,
+        )
+        return
+
+    asset: Entity = env.scene[asset_cfg.name]
+    local_body_ids = _selected_local_body_ids(asset, asset_cfg, env.device)
+    model_body_ids = asset.indexing.body_ids[local_body_ids]
+    target_env_ids = (
+        torch.arange(env.num_envs, device=env.device, dtype=torch.int)
+        if env_ids is None
+        else env_ids.to(env.device, dtype=torch.int)
     )
+
+    for local_body_id, model_body_id in zip(local_body_ids.tolist(), model_body_ids.tolist(), strict=True):
+        default_masses = _default_body_masses(env, target_env_ids, model_body_id)
+        default_mass = default_masses.flatten()[0]
+        if not torch.allclose(default_masses, default_mass.expand_as(default_masses)):
+            raise ValueError(
+                "pseudo-inertia add/abs randomization requires a shared default mass per selected body."
+            )
+        mass = float(default_mass.item())
+        if operation == "add":
+            scale_range = (
+                (mass + mass_distribution_params[0]) / mass,
+                (mass + mass_distribution_params[1]) / mass,
+            )
+        elif operation == "abs":
+            scale_range = (mass_distribution_params[0] / mass, mass_distribution_params[1] / mass)
+        else:
+            raise ValueError(f"Unsupported mass randomization operation: {operation}")
+        alpha_range = _mass_scale_to_alpha_range(scale_range)
+        dr.pseudo_inertia(
+            env=env,
+            env_ids=target_env_ids,
+            alpha_range=alpha_range,
+            distribution=pseudo_inertia_distribution,
+            asset_cfg=SceneEntityCfg(asset_cfg.name, body_ids=[local_body_id]),
+        )
+
+
+def _mass_scale_to_alpha_range(scale_range: tuple[float, float]) -> tuple[float, float]:
+    if scale_range[0] <= 0.0 or scale_range[1] <= 0.0:
+        raise ValueError("Pseudo-inertia mass scale range must stay positive.")
+    return (0.5 * math.log(scale_range[0]), 0.5 * math.log(scale_range[1]))
+
+
+def _selected_local_body_ids(asset: Entity, asset_cfg: SceneEntityCfg, device: torch.device) -> torch.Tensor:
+    all_local_body_ids = torch.arange(asset.indexing.body_ids.numel(), device=device, dtype=torch.long)
+    return all_local_body_ids[asset_cfg.body_ids].reshape(-1)
+
+
+def _default_body_masses(env, env_ids: torch.Tensor, model_body_id: int) -> torch.Tensor:
+    default_body_mass = env.sim.get_default_field("body_mass")
+    if "body_mass" in env.sim.per_world_default_fields:
+        return default_body_mass[env_ids, model_body_id]
+    return default_body_mass[model_body_id].reshape(1)
 
 
 def reset_joints_by_scale(

--- a/src/instinct_mj/tasks/parkour/config/g1/agents/instinct_rl_amp_cfg.py
+++ b/src/instinct_mj/tasks/parkour/config/g1/agents/instinct_rl_amp_cfg.py
@@ -83,7 +83,7 @@ class G1ParkourPPORunnerCfg(InstinctRlOnPolicyRunnerCfg):
     policy_observation_group: str = "policy"
     critic_observation_group: str = "critic"
     max_iterations: int = 30000
-    save_interval: int = 1000
+    save_interval: int = 5000
     experiment_name: str = "g1_parkour"
     resume: bool = False
     load_run: str = "^(?!_play$).*"

--- a/src/instinct_mj/tasks/parkour/config/g1/g1_parkour_target_amp_cfg.py
+++ b/src/instinct_mj/tasks/parkour/config/g1/g1_parkour_target_amp_cfg.py
@@ -1,7 +1,7 @@
 """G1 parkour AMP task config factories.
 
 Config is built via factory functions that return a fully-built
-``ManagerBasedRlEnvCfg``.
+``G1ParkourAmpEnvCfg``.
 """
 
 from __future__ import annotations
@@ -12,7 +12,6 @@ import os
 from dataclasses import dataclass, field
 
 import mujoco
-from mjlab.envs import ManagerBasedRlEnvCfg
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers import (
     CurriculumTermCfg,
@@ -31,6 +30,7 @@ from mjlab.sensor import (
     PinholeCameraPatternCfg,
     RayCastSensorCfg,
 )
+from mjlab.scene import SceneCfg
 from mjlab.tasks.tracking.config.g1.env_cfgs import unitree_g1_flat_tracking_env_cfg
 from mjlab.utils.noise import UniformNoiseCfg
 from mjlab.viewer.viewer_config import ViewerConfig
@@ -44,6 +44,7 @@ from instinct_mj.assets.unitree_g1 import (
     beyondmimic_action_scale,
     beyondmimic_g1_29dof_delayed_actuator_cfgs,
 )
+from instinct_mj.envs.manager_based_rl_env_cfg import InstinctLabRLEnvCfg
 from instinct_mj.motion_reference.motion_files.amass_motion_cfg import AmassMotionCfg as AmassMotionCfgBase
 from instinct_mj.motion_reference.motion_reference_cfg import MotionReferenceManagerCfg
 from instinct_mj.motion_reference.utils import motion_interpolate_bilinear
@@ -65,7 +66,6 @@ __file_dir__ = os.path.dirname(os.path.realpath(__file__))
 # Example:
 # _PARKOUR_DATASET_DIR = os.path.expanduser("~/your/path/to/parkour_motion_reference")
 _PARKOUR_DATASET_DIR = os.path.expanduser("~/Xyk/Datasets/data&model/parkour_motion_reference")
-
 
 # ---------------------------------------------------------------------------
 # Motion reference configs
@@ -145,11 +145,36 @@ def _parkour_g1_with_shoe_spec() -> mujoco.MjSpec:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(kw_only=True)
+class G1ParkourSceneCfg(SceneCfg):
+    """Scene configuration for the G1 Parkour task."""
+
+
+@dataclass(kw_only=True)
+class G1ParkourAmpEnvCfg(InstinctLabRLEnvCfg):
+    """Dictionary-manager environment configuration for G1 Parkour AMP."""
+
+    scene: G1ParkourSceneCfg = field(default_factory=G1ParkourSceneCfg)
+    decimation: int = 4
+    observations: dict = field(default_factory=dict)
+    actions: dict = field(default_factory=dict)
+    rewards: dict = field(default_factory=lambda: {"rewards": {}})
+    terminations: dict = field(default_factory=dict)
+    commands: dict = field(default_factory=dict)
+    events: dict = field(default_factory=dict)
+    curriculum: dict = field(default_factory=dict)
+    monitors: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # All managers are already dicts, no conversion needed!
+        pass
+
+
 def instinct_g1_parkour_amp_env_cfg(
     *,
     play: bool = False,
     shoe: bool = True,
-) -> ManagerBasedRlEnvCfg:
+) -> G1ParkourAmpEnvCfg:
     """Build the base G1 parkour AMP environment configuration.
 
     Args:
@@ -158,10 +183,39 @@ def instinct_g1_parkour_amp_env_cfg(
       shoe: If True, apply shoe-specific adjustments (default is True).
 
     Returns:
-      A ``ManagerBasedRlEnvCfg`` instance with parkour settings applied.
+      A ``G1ParkourAmpEnvCfg`` instance with parkour settings applied.
     """
-    cfg = unitree_g1_flat_tracking_env_cfg(play=play, has_state_estimation=True)
-    cfg.monitors = {}
+    tracking_cfg = unitree_g1_flat_tracking_env_cfg(play=play, has_state_estimation=True)
+    tracking_scene = tracking_cfg.scene
+    cfg = G1ParkourAmpEnvCfg(
+        decimation=tracking_cfg.decimation,
+        scene=G1ParkourSceneCfg(
+            num_envs=tracking_scene.num_envs,
+            env_spacing=tracking_scene.env_spacing,
+            terrain=tracking_scene.terrain,
+            entities=tracking_scene.entities,
+            sensors=tracking_scene.sensors,
+            extent=tracking_scene.extent,
+            spec_fn=tracking_scene.spec_fn,
+        ),
+        observations=tracking_cfg.observations,
+        actions=tracking_cfg.actions,
+        events=tracking_cfg.events,
+        seed=tracking_cfg.seed,
+        sim=tracking_cfg.sim,
+        viewer=tracking_cfg.viewer,
+        episode_length_s=tracking_cfg.episode_length_s,
+        rewards={"rewards": tracking_cfg.rewards},
+        terminations=tracking_cfg.terminations,
+        commands=tracking_cfg.commands,
+        curriculum=tracking_cfg.curriculum,
+        metrics=tracking_cfg.metrics,
+        recorders=tracking_cfg.recorders,
+        is_finite_horizon=tracking_cfg.is_finite_horizon,
+        auto_reset=tracking_cfg.auto_reset,
+        scale_rewards_by_dt=tracking_cfg.scale_rewards_by_dt,
+        monitors={},
+    )
     cfg.viewer.origin_type = ViewerConfig.OriginType.WORLD
     cfg.viewer.entity_name = None
     cfg.viewer.body_name = None
@@ -598,7 +652,7 @@ def instinct_g1_parkour_amp_env_cfg(
         enable_corruption=False,
     )
 
-    cfg.rewards = {
+    cfg.rewards = {"rewards": {
         # ---------- Task rewards ----------
         "track_lin_vel_xy_exp": RewardTermCfg(
             func=parkour_mdp.track_lin_vel_xy_exp,
@@ -768,7 +822,7 @@ def instinct_g1_parkour_amp_env_cfg(
             weight=-1.0,
             params={"sensor_name": "undesired_contact_forces", "threshold": 1.0},
         ),
-    }
+    }}
     cfg.curriculum = {
         "terrain_levels": CurriculumTermCfg(
             func=parkour_mdp.tracking_exp_vel,
@@ -869,7 +923,7 @@ def instinct_g1_parkour_amp_env_cfg(
         leg_volume_points.points_generator.z_max = -0.023
 
         # Adjust feet_at_plane height offset for shoes
-        cfg.rewards["feet_at_plane"].params["height_offset"] = 0.058
+        cfg.rewards["rewards"]["feet_at_plane"].params["height_offset"] = 0.058
 
     if play:
         cfg.scene.num_envs = 10
@@ -907,7 +961,7 @@ def instinct_g1_parkour_amp_final_cfg(
     *,
     play: bool = False,
     shoe: bool = True,
-) -> ManagerBasedRlEnvCfg:
+) -> G1ParkourAmpEnvCfg:
     """Create the final G1 parkour AMP env configuration.
 
     Args:
@@ -917,7 +971,7 @@ def instinct_g1_parkour_amp_final_cfg(
         matching the original ``G1ParkourEnvCfg``).
 
     Returns:
-      A fully-built ``ManagerBasedRlEnvCfg`` instance.
+      A fully-built ``G1ParkourAmpEnvCfg`` instance.
     """
     # Build base parkour config (already includes play overrides if requested)
     cfg = instinct_g1_parkour_amp_env_cfg(play=play, shoe=shoe)

--- a/src/instinct_mj/tasks/parkour/config/parkour_env_cfg.py
+++ b/src/instinct_mj/tasks/parkour/config/parkour_env_cfg.py
@@ -273,6 +273,8 @@ ROUGH_TERRAINS_CFG = FiledTerrainGeneratorCfg(
 )
 
 ROUGH_TERRAINS_CFG_PLAY = copy.deepcopy(ROUGH_TERRAINS_CFG)
+for sub_terrain_cfg in ROUGH_TERRAINS_CFG_PLAY.sub_terrains.values():
+    sub_terrain_cfg.wall_prob = [0.0, 0.0, 0.0, 0.0]
 ROUGH_TERRAINS_CFG_PLAY.num_rows = 4
 ROUGH_TERRAINS_CFG_PLAY.num_cols = 10
 

--- a/src/instinct_mj/tasks/shadowing/beyondmimic/beyondmimic_env_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/beyondmimic/beyondmimic_env_cfg.py
@@ -301,7 +301,7 @@ def make_beyondmimic_rewards() -> dict[str, RewTermCfg | None]:
                 "difference_type": "axis_angle",
             },
         ),
-        "motion_body_pos": RewTermCfg(
+        "link_pos_imitation_gauss": RewTermCfg(
             func=instinct_mdp.link_pos_imitation_gauss,
             weight=1.0,
             params={
@@ -311,7 +311,7 @@ def make_beyondmimic_rewards() -> dict[str, RewTermCfg | None]:
                 "std": 0.3,
             },
         ),
-        "motion_body_ori": RewTermCfg(
+        "link_rot_imitation_gauss": RewTermCfg(
             func=instinct_mdp.link_rot_imitation_gauss,
             weight=1.0,
             params={
@@ -321,7 +321,7 @@ def make_beyondmimic_rewards() -> dict[str, RewTermCfg | None]:
                 "std": 0.4,
             },
         ),
-        "motion_body_lin_vel": RewTermCfg(
+        "link_lin_vel_imitation_gauss": RewTermCfg(
             func=instinct_mdp.link_lin_vel_imitation_gauss,
             weight=1.0,
             params={
@@ -329,7 +329,7 @@ def make_beyondmimic_rewards() -> dict[str, RewTermCfg | None]:
                 "std": 1.0,
             },
         ),
-        "motion_body_ang_vel": RewTermCfg(
+        "link_ang_vel_imitation_gauss": RewTermCfg(
             func=instinct_mdp.link_ang_vel_imitation_gauss,
             weight=1.0,
             params={
@@ -591,7 +591,7 @@ class BeyondMimicEnvCfg(InstinctLabRLEnvCfg):
     commands: dict = field(default_factory=make_beyondmimic_commands)
     actions: dict = field(default_factory=make_beyondmimic_actions)
     observations: dict = field(default_factory=make_beyondmimic_observations)
-    rewards: dict = field(default_factory=make_beyondmimic_rewards)
+    rewards: dict = field(default_factory=lambda: {"rewards": make_beyondmimic_rewards()})
     events: dict = field(default_factory=make_beyondmimic_events)
     curriculum: dict = field(default_factory=make_beyondmimic_curriculum)
     terminations: dict = field(default_factory=make_beyondmimic_terminations)

--- a/src/instinct_mj/tasks/shadowing/beyondmimic/config/g1/beyondmimic_plane_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/beyondmimic/config/g1/beyondmimic_plane_cfg.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 
 import mjlab.envs.mdp as mdp
 import yaml
-from mjlab.envs import ManagerBasedRlEnvCfg
 from mjlab.managers import (
     CurriculumTermCfg,
     EventTermCfg,
@@ -25,7 +24,6 @@ from mjlab.viewer.viewer_config import ViewerConfig
 import instinct_mj.envs.mdp as instinct_mdp
 import instinct_mj.tasks.shadowing.beyondmimic.beyondmimic_env_cfg as beyondmimic_cfg
 from instinct_mj.assets.unitree_g1 import G1_29DOF_TORSOBASE_POPSICLE_CFG, G1_MJCF_PATH, beyondmimic_action_scale
-from instinct_mj.envs.manager_based_rl_env_cfg import InstinctLabRLEnvCfg
 from instinct_mj.monitors import (
     ActuatorMonitorTerm,
     MonitorTermCfg,
@@ -48,8 +46,10 @@ G1_CFG = G1_29DOF_TORSOBASE_POPSICLE_CFG
 # NOTE: Change `MOTION_NAME`, `_hacked_selected_file_`, and the dataset path below
 # to your local motion setup before training / play.
 # Keep `_hacked_selected_file_` relative to the dataset root configured in `path`.
-MOTION_NAME = "LafanWalk1"
-_hacked_selected_file_ = "walk1_subject1_retargeted.npz"
+MOTION_NAME = "LafanKungfu1"
+_hacked_selected_file_ = "fightAndSports1_subject1_retargetted.npz"
+MOTION_NAME = "LafanSprint1"
+_hacked_selected_file_ = "sprint1_subject2_retargetted.npz"
 
 with open(f"/tmp/{MOTION_NAME}.yaml", "w") as f:
     yaml.dump(
@@ -94,7 +94,9 @@ motion_reference_cfg = MotionReferenceManagerCfg(
         MOTION_NAME: AmassMotionCfgBase(
             # NOTE: Replace this with your local BeyondMimic motion dataset root.
             # Example: os.path.expanduser("~/your/path/to/lafan1_gmr_unitree_g1_instinct")
-            path=os.path.expanduser("~/Xyk/Datasets/lafan1_gmr_unitree_g1_instinct"),
+            path=os.path.expanduser(
+                "~/Xyk/Datasets/UbisoftLAFAN1_GMR_g1_29dof_torsoBase_retargetted_instinctnpz"
+            ),
             retargetting_func=None,
             filtered_motion_selection_filepath=f"/tmp/{MOTION_NAME}.yaml",
             motion_start_from_middle_range=[0.0, 0.8],
@@ -507,7 +509,7 @@ def _monitors_cfg(*, play: bool) -> dict[str, MonitorTermCfg]:
     return monitors
 
 
-def g1_beyondmimic_plane_env_cfg(*, play: bool = False) -> ManagerBasedRlEnvCfg:
+def g1_beyondmimic_plane_env_cfg(*, play: bool = False) -> beyondmimic_cfg.BeyondMimicEnvCfg:
     active_motion_reference_cfg = deepcopy(motion_reference_cfg_play if play else motion_reference_cfg)
     if play:
         robot_reference = deepcopy(G1_CFG)
@@ -575,12 +577,12 @@ def g1_beyondmimic_plane_env_cfg(*, play: bool = False) -> ManagerBasedRlEnvCfg:
         ),
     )
 
-    cfg = InstinctLabRLEnvCfg(
+    cfg = beyondmimic_cfg.BeyondMimicEnvCfg(
         scene=scene,
         actions=_actions_cfg(),
         observations=_observations_cfg(link_of_interests=list(active_motion_reference_cfg.link_of_interests)),
         commands=_commands_cfg(),
-        rewards=deepcopy(beyondmimic_cfg.make_beyondmimic_rewards()),
+        rewards={"rewards": deepcopy(beyondmimic_cfg.make_beyondmimic_rewards())},
         events=_events_cfg(),
         curriculum=_curriculum_cfg(),
         terminations=_terminations_cfg(),
@@ -657,20 +659,20 @@ def g1_beyondmimic_plane_env_cfg(*, play: bool = False) -> ManagerBasedRlEnvCfg:
             ("_linVelObs" if "base_lin_vel" in policy_terms and policy_terms["base_lin_vel"].scale != 0.0 else ""),
             f"_{MOTION_NAME}",
             ("_noPush" if cfg.events["push_robot"] is None else ""),
-            ("_noContactPenalty" if cfg.rewards["undesired_contacts"] is None else ""),
+            ("_noContactPenalty" if cfg.rewards["rewards"]["undesired_contacts"] is None else ""),
             "_GmrMotion",
         ]
     )
     return cfg
 
 
-def G1BeyondMimicPlaneEnvCfg() -> ManagerBasedRlEnvCfg:
+def G1BeyondMimicPlaneEnvCfg() -> beyondmimic_cfg.BeyondMimicEnvCfg:
     """Return the train env config."""
 
     return g1_beyondmimic_plane_env_cfg(play=False)
 
 
-def G1BeyondMimicPlaneEnvCfg_PLAY() -> ManagerBasedRlEnvCfg:
+def G1BeyondMimicPlaneEnvCfg_PLAY() -> beyondmimic_cfg.BeyondMimicEnvCfg:
     """Return the play env config."""
 
     return g1_beyondmimic_plane_env_cfg(play=True)

--- a/src/instinct_mj/tasks/shadowing/perceptive/config/g1/agents/instinct_rl_ppo_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive/config/g1/agents/instinct_rl_ppo_cfg.py
@@ -40,7 +40,7 @@ class Conv2dHeadEncoderCfg:
 
         takeout_input_components: bool = True
 
-    depth_image: object = field(default_factory=lambda: DepthImageEncoderCfg())
+    depth_image: object = field(default_factory=DepthImageEncoderCfg)
 
 
 @dataclass(kw_only=True)
@@ -115,7 +115,6 @@ class G1PerceptiveShadowingPPORunnerCfg(InstinctRlOnPolicyRunnerCfg):
     load_run: object | None = None
 
     def __post_init__(self):
-        super().__post_init__()
         self.resume = self.load_run is not None
         self.run_name = "".join(
             [

--- a/src/instinct_mj/tasks/shadowing/perceptive/config/g1/agents/instinct_rl_vae_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive/config/g1/agents/instinct_rl_vae_cfg.py
@@ -41,7 +41,7 @@ class Conv2dHeadEncoderCfg:
 
         takeout_input_components: bool = True
 
-    depth_image: object = field(default_factory=lambda: DepthImageEncoderCfg())
+    depth_image: object = field(default_factory=DepthImageEncoderCfg)
 
 
 @dataclass(kw_only=True)
@@ -61,6 +61,12 @@ class PolicyCfg(InstinctRlEncoderActorCriticCfg):
 
 @dataclass(kw_only=True)
 class VaePolicyCfg(InstinctRlEncoderVaeActorCriticCfg):
+    init_noise_std: float = 1e-4
+
+    critic_hidden_dims: list = field(default_factory=lambda: [512, 256, 128])
+
+    activation: str = "elu"
+
     encoder_configs: object = field(default_factory=lambda: Conv2dHeadEncoderCfg())
 
     vae_encoder_kwargs: dict = field(
@@ -221,7 +227,6 @@ class G1PerceptiveVaePPORunnerCfg(InstinctRlOnPolicyRunnerCfg):
     load_run: object | None = None
 
     def __post_init__(self):
-        super().__post_init__()
         self.resume = self.load_run is not None
         self.run_name = "".join(
             [

--- a/src/instinct_mj/tasks/shadowing/perceptive/config/g1/perceptive_shadowing_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive/config/g1/perceptive_shadowing_cfg.py
@@ -30,7 +30,7 @@ G1_CFG = G1_29DOF_TORSOBASE_POPSICLE_CFG
 
 # NOTE: Change this if your local perceptive shadowing dataset lives elsewhere.
 # The folder should contain the motion files and a `metadata.yaml`.
-MOTION_FOLDER = "~/Xyk/Datasets/20251116_50cm_kneeClimbStep1"
+MOTION_FOLDER = "~/Xyk/Datasets/her_leveled"
 
 # NOTE: Optional play override for perceptive shadowing.
 # Leave this as `None` to reuse `MOTION_FOLDER`, or set it to another local
@@ -148,11 +148,12 @@ class TerrainMotionCfg(TerrainMotionCfgBase):
 
     max_origins_per_motion: int = 49
 
-    ensure_link_below_zero_ground: bool = False
+    # Lift reset poses away from the terrain to reduce early pelvis/hip contacts.
+    ensure_link_below_zero_ground: bool = True
 
     motion_start_from_middle_range: list = field(default_factory=lambda: [0.0, 0.0])
 
-    motion_start_height_offset: float = 0.0
+    motion_start_height_offset: float = 0.1
 
     motion_bin_length_s: float = 1.0
 
@@ -234,7 +235,7 @@ motion_reference_cfg_play.reference_entity_name = "robot_reference"
 class G1PerceptiveShadowingEnvCfg(perceptual_cfg.PerceptiveShadowingEnvCfg):
     scene: perceptual_cfg.PerceptiveShadowingSceneCfg = field(
         default_factory=lambda: perceptual_cfg.PerceptiveShadowingSceneCfg(
-            num_envs=3072,
+            num_envs=1024,
             entities={"robot": deepcopy(G1_CFG)},
             sensors=perceptual_cfg.make_perceptive_scene_sensors(
                 motion_reference=deepcopy(motion_reference_cfg),
@@ -273,7 +274,10 @@ class G1PerceptiveShadowingEnvCfg(perceptual_cfg.PerceptiveShadowingEnvCfg):
             terrain_cfg = self.scene.terrain.terrain_generator.sub_terrains["motion_matched"]
             terrain_cfg.path = motion_buffer.path
             terrain_cfg.metadata_yaml = motion_buffer.metadata_yaml
-        _maybe_disable_single_motion_binning(motion_buffer)
+        single_motion_without_bins = _maybe_disable_single_motion_binning(motion_buffer)
+        if single_motion_without_bins:
+            self.curriculum["beyond_adaptive_sampling"] = None
+            self.events["bin_fail_counter_smoothing"] = None
         active_motion_name = list(motion_reference_cfg.motion_buffers.keys())[0]
         active_motion_buffer = motion_reference_cfg.motion_buffers[active_motion_name]
 
@@ -294,6 +298,8 @@ class G1PerceptiveShadowingEnvCfg(perceptual_cfg.PerceptiveShadowingEnvCfg):
                 ),
             ]
         )
+        if single_motion_without_bins:
+            self.run_name = self.run_name.replace("_concatMotionBins", "_independentMotionBins")
 
 
 @dataclass(kw_only=True)
@@ -318,7 +324,7 @@ class G1PerceptiveShadowingEnvCfg_PLAY(G1PerceptiveShadowingEnvCfg):
             distance=2.1213,
             elevation=45.0,
             azimuth=0.0,
-            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            origin_type=ViewerConfig.OriginType.WORLD,
             entity_name="robot",
             body_name="torso_link",
         )
@@ -351,8 +357,8 @@ class G1PerceptiveShadowingEnvCfg_PLAY(G1PerceptiveShadowingEnvCfg):
             terrain_cfg = self.scene.terrain.terrain_generator.sub_terrains["motion_matched"]
             terrain_cfg.path = motion_buffer.path
             terrain_cfg.metadata_yaml = motion_buffer.metadata_yaml
-            self.scene.terrain.terrain_generator.num_rows = 6
-            self.scene.terrain.terrain_generator.num_cols = 6
+            self.scene.terrain.terrain_generator.num_rows = 1
+            self.scene.terrain.terrain_generator.num_cols = 1
         self.run_name = self.run_name.replace("_concatMotionBins", "_independentMotionBins")
         # self.scene.motion_reference.motion_buffers.pop(MOTION_NAME)
         # self.scene.motion_reference.motion_buffers["AMASSMotion"] = AMASSMotionCfg()
@@ -376,6 +382,7 @@ class G1PerceptiveShadowingEnvCfg_PLAY(G1PerceptiveShadowingEnvCfg):
         # put the reference in scene and move the robot elsewhere and visualize the reference
         # self.events.reset_robot.params["position_offset"] = [0.0, 1.0, 2.0]
         # self.scene.motion_reference.visualizing_robot_offset = (0.0, 0.0, 0.0)
+        motion_reference_cfg.visualizing_robot_offset = (0.0, 1.0, 0.0)
         # self.viewer.entity_name = "robot_reference"
 
         # remove some randomizations

--- a/src/instinct_mj/tasks/shadowing/perceptive/config/g1/perceptive_vae_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive/config/g1/perceptive_vae_cfg.py
@@ -57,7 +57,7 @@ class TerrainMotionCfg(TerrainMotionCfgBase):
     # metadata file lives at another location.
     metadata_yaml: object = field(default_factory=lambda: os.path.expanduser(f"{MOTION_FOLDER}/metadata.yaml"))
 
-    max_origins_per_motion: int = 49
+    max_origins_per_motion: int = 9
 
     ensure_link_below_zero_ground: bool = False
 
@@ -294,7 +294,7 @@ class G1PerceptiveVaeEnvCfg_PLAY(G1PerceptiveVaeEnvCfg):
             distance=3.2016,
             elevation=51.3402,
             azimuth=90.0,
-            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            origin_type=ViewerConfig.OriginType.WORLD,
             entity_name="robot",
             body_name="torso_link",
         )
@@ -336,8 +336,9 @@ class G1PerceptiveVaeEnvCfg_PLAY(G1PerceptiveVaeEnvCfg):
         terrain_cfg.metadata_yaml = motion_buffer.metadata_yaml
 
         # Use non-terrain-matching motion and plane to hack the scene.
-        self.scene.terrain.terrain_generator.num_rows = 6
-        self.scene.terrain.terrain_generator.num_cols = 6
+        # A single terrain tile is enough for play and keeps the imported terrain triangle budget manageable.
+        self.scene.terrain.terrain_generator.num_rows = 1
+        self.scene.terrain.terrain_generator.num_cols = 1
         # self.scene.motion_reference.motion_buffers.pop(MOTION_NAME)
         # self.scene.motion_reference.motion_buffers["AMASSMotion"] = AMASSMotionCfg()
         # self.scene.motion_reference.motion_buffers["AMASSMotion"].motion_start_from_middle_range = [0.0, 0.0]

--- a/src/instinct_mj/tasks/shadowing/perceptive/config/g1/rl_cfgs.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive/config/g1/rl_cfgs.py
@@ -1,190 +1,23 @@
 """Instinct-RL configs for G1 perceptive shadowing tasks."""
 
-from __future__ import annotations
-
-import os
-
-from instinct_mj.rl import (
-    InstinctRlActorCriticCfg,
-    InstinctRlNormalizerCfg,
-    InstinctRlOnPolicyRunnerCfg,
-    InstinctRlPpoAlgorithmCfg,
+from instinct_mj.rl import InstinctRlOnPolicyRunnerCfg
+from instinct_mj.tasks.shadowing.perceptive.config.g1.agents.instinct_rl_ppo_cfg import (
+    G1PerceptiveShadowingPPORunnerCfg,
 )
-from instinct_mj.tasks.config.rl_utils import default_policy_critic_normalizers
-
-
-def _perceptive_depth_encoder_cfg() -> dict[str, dict]:
-    return {
-        "depth_image": {
-            "class_name": "Conv2dHeadModel",
-            "component_names": ["depth_image"],
-            "output_size": 32,
-            "takeout_input_components": True,
-            "channels": [32, 32],
-            "kernel_sizes": [3, 3],
-            "strides": [1, 1],
-            "hidden_sizes": [32],
-            "paddings": [1, 1],
-            "nonlinearity": "ReLU",
-            "use_maxpool": False,
-        }
-    }
+from instinct_mj.tasks.shadowing.perceptive.config.g1.agents.instinct_rl_vae_cfg import (
+    G1PerceptiveVaePPORunnerCfg,
+)
 
 
 def g1_perceptive_shadowing_instinct_rl_cfg() -> InstinctRlOnPolicyRunnerCfg:
-    # Use EncoderActorCritic with the depth encoder.
-    return InstinctRlOnPolicyRunnerCfg(
-        policy=InstinctRlActorCriticCfg(
-            class_name="EncoderActorCritic",
-            init_noise_std=1.0,
-            actor_hidden_dims=(512, 256, 128),
-            critic_hidden_dims=(512, 256, 128),
-            activation="elu",
-            encoder_configs=_perceptive_depth_encoder_cfg(),
-            critic_encoder_configs=None,
-        ),
-        algorithm=InstinctRlPpoAlgorithmCfg(
-            class_name="PPO",
-            value_loss_coef=1.0,
-            use_clipped_value_loss=True,
-            clip_param=0.2,
-            entropy_coef=0.005,
-            num_learning_epochs=5,
-            num_mini_batches=4,
-            learning_rate=1.0e-3,
-            schedule="adaptive",
-            gamma=0.99,
-            lam=0.95,
-            desired_kl=0.01,
-            max_grad_norm=1.0,
-        ),
-        normalizers=default_policy_critic_normalizers(),
-        num_steps_per_env=24,
-        max_iterations=50_000,
-        save_interval=1_000,
-        log_interval=10,
-        experiment_name="g1_perceptive_shadowing",
-        policy_observation_group="policy",
-        critic_observation_group="critic",
-    )
+    return G1PerceptiveShadowingPPORunnerCfg()
 
 
 def g1_perceptive_shadowing_one_motion_instinct_rl_cfg() -> InstinctRlOnPolicyRunnerCfg:
-    cfg = g1_perceptive_shadowing_instinct_rl_cfg()
+    cfg = G1PerceptiveShadowingPPORunnerCfg()
     cfg.experiment_name = "g1_perceptive_shadowing_one_motion"
     return cfg
 
 
-def _perceptive_vae_teacher_policy_cfg() -> dict[str, object]:
-    return {
-        "init_noise_std": 1.0,
-        "actor_hidden_dims": [512, 256, 128],
-        "critic_hidden_dims": [512, 256, 128],
-        "activation": "elu",
-        "encoder_configs": {
-            "depth_image": {
-                "class_name": "Conv2dHeadModel",
-                "component_names": ["depth_image"],
-                "output_size": 32,
-                "takeout_input_components": True,
-                "channels": [32, 32],
-                "kernel_sizes": [3, 3],
-                "strides": [1, 1],
-                "hidden_sizes": [32],
-                "paddings": [1, 1],
-                "nonlinearity": "ReLU",
-                "use_maxpool": False,
-            }
-        },
-        "critic_encoder_configs": None,
-        "obs_format": {
-            "policy": {
-                "joint_pos_ref": (10, 29),
-                "joint_vel_ref": (10, 29),
-                "position_ref": (10, 3),
-                "rotation_ref": (10, 6),
-                "depth_image": (1, 18, 32),
-                "projected_gravity": (24,),
-                "base_ang_vel": (24,),
-                "joint_pos": (232,),
-                "joint_vel": (232,),
-                "last_action": (232,),
-            },
-            "critic": {
-                "joint_pos_ref": (10, 29),
-                "joint_vel_ref": (10, 29),
-                "position_ref": (10, 3),
-                "link_pos": (14, 3),
-                "link_rot": (14, 6),
-                "height_scan": (187,),
-                "base_lin_vel": (24,),
-                "base_ang_vel": (24,),
-                "joint_pos": (232,),
-                "joint_vel": (232,),
-                "last_action": (232,),
-            },
-        },
-        "num_actions": 29,
-        "num_rewards": 1,
-    }
-
-
 def g1_perceptive_vae_instinct_rl_cfg() -> InstinctRlOnPolicyRunnerCfg:
-    return InstinctRlOnPolicyRunnerCfg(
-        policy=InstinctRlActorCriticCfg(
-            class_name="EncoderVaeActorCritic",
-            init_noise_std=1.0e-4,
-            critic_hidden_dims=(512, 256, 128),
-            activation="elu",
-            encoder_configs=_perceptive_depth_encoder_cfg(),
-            critic_encoder_configs=None,
-            vae_encoder_kwargs={
-                "hidden_sizes": [256, 128, 64],
-                "nonlinearity": "ELU",
-            },
-            vae_decoder_kwargs={
-                "hidden_sizes": [512, 256, 128],
-                "nonlinearity": "ELU",
-            },
-            vae_latent_size=16,
-            vae_input_subobs_components=("parallel_latent_0_depth_image",),
-            vae_aux_subobs_components=(
-                "projected_gravity",
-                "base_ang_vel",
-                "joint_pos",
-                "joint_vel",
-                "last_action",
-            ),
-        ),
-        algorithm=InstinctRlPpoAlgorithmCfg(
-            class_name="VaeDistill",
-            kl_loss_func="kl_divergence",
-            kl_loss_coef=1.0,
-            using_ppo=False,
-            num_learning_epochs=5,
-            num_mini_batches=4,
-            learning_rate=1.0e-3,
-            schedule="adaptive",
-            gamma=0.99,
-            lam=0.95,
-            desired_kl=0.01,
-            max_grad_norm=1.0,
-            teacher_act_prob=0.2,
-            teacher_policy_class_name="EncoderActorCritic",
-            teacher_policy=_perceptive_vae_teacher_policy_cfg(),
-            teacher_logdir=os.path.expanduser(
-                "~/Xyk/Project-Instinct/InstinctMJ/logs/instinct_rl/g1_perceptive_shadowing/2026-03-07_15-29-45"
-            ),
-        ),
-        normalizers={
-            # NOTE: No critic normalizer, must be loaded from the teacher policy.
-            "policy": InstinctRlNormalizerCfg(),
-        },
-        num_steps_per_env=24,
-        max_iterations=50_000,
-        save_interval=1_000,
-        log_interval=10,
-        experiment_name="g1_perceptive_vae",
-        policy_observation_group="policy",
-        critic_observation_group="critic",
-    )
+    return G1PerceptiveVaePPORunnerCfg()

--- a/src/instinct_mj/tasks/shadowing/perceptive/perceptive_env_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive/perceptive_env_cfg.py
@@ -175,11 +175,11 @@ class PerceptiveShadowingSceneCfg(SceneCfg):
         default_factory=lambda: TerrainImporterCfg(
             terrain_type="hacked_generator",
             terrain_generator=FiledTerrainGeneratorCfg(
-                size=(9, 12),
+                size=(30, 16),
                 border_width=0.0,
                 border_height=0.0,
-                num_rows=7,
-                num_cols=7,
+                num_rows=3,
+                num_cols=3,
                 add_lights=True,
                 sub_terrains={
                     # MotionMatchedTerrainCfg keeps motion-terrain pairing from metadata.yaml.
@@ -188,6 +188,7 @@ class PerceptiveShadowingSceneCfg(SceneCfg):
                         proportion=1.0,
                         path="PLACEHOLDER",  # Will be overridden in concrete env cfg __post_init__
                         metadata_yaml="PLACEHOLDER",  # Will be overridden in concrete env cfg __post_init__
+                        use_input_origin_frame=True,
                         collision_coacd=True,
                         # Use CoACD hulls directly as rendered terrain mesh (instead of source STL mesh).
                         collision_coacd_visualize_collision_hulls=True,
@@ -218,7 +219,7 @@ class PerceptiveShadowingSceneCfg(SceneCfg):
                 primary=ContactMatch(mode="body", pattern=".*", entity="robot"),
                 secondary=ContactMatch(mode="body", pattern="terrain"),
                 fields=("found", "force"),
-                reduce="maxforce",
+                reduce="netforce",
                 history_length=3,
                 track_air_time=True,
             ),
@@ -303,7 +304,7 @@ def make_perceptive_scene_sensors(
             primary=ContactMatch(mode="body", pattern=".*", entity="robot"),
             secondary=ContactMatch(mode="body", pattern="terrain"),
             fields=("found", "force"),
-            reduce="maxforce",
+            reduce="netforce",
             history_length=3,
             track_air_time=True,
         )
@@ -953,7 +954,7 @@ class PerceptiveShadowingEnvCfg(InstinctLabRLEnvCfg):
     commands: dict = field(default_factory=make_perceptive_commands)
     actions: dict = field(default_factory=make_actions)
     observations: dict = field(default_factory=make_observations)
-    rewards: dict = field(default_factory=make_rewards)
+    rewards: dict = field(default_factory=lambda: {"rewards": make_rewards()})
     events: dict = field(default_factory=make_events)
     curriculum: dict = field(default_factory=make_curriculum)
     terminations: dict = field(default_factory=make_terminations)

--- a/src/instinct_mj/tasks/shadowing/perceptive/perceptive_env_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive/perceptive_env_cfg.py
@@ -717,7 +717,7 @@ def make_events() -> dict[str, EventTermCfg]:
             },
         ),
         "randomize_rigid_body_mass": EventTermCfg(
-            func=mdp.dr.body_mass,
+            func=mdp.dr.pseudo_inertia,
             mode="startup",
             params={
                 "asset_cfg": SceneEntityCfg(
@@ -730,9 +730,8 @@ def make_events() -> dict[str, EventTermCfg]:
                         "right_wrist.*",
                     ],
                 ),
-                "ranges": (0.8, 1.2),
-                "operation": "scale",
-                "distribution": "uniform",
+                "alpha_range": (0.5 * math.log(0.8), 0.5 * math.log(1.2)),
+                "distribution": instinct_mdp.uniform_mass_scale_to_alpha,
             },
         ),
         "match_motion_ref_with_scene": EventTermCfg(

--- a/src/instinct_mj/tasks/shadowing/perceptive_hoi/config/g1/perceptive_shadowing_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive_hoi/config/g1/perceptive_shadowing_cfg.py
@@ -58,7 +58,7 @@ G1_29DOF_LINKS = [
     "right_ankle_roll_link",
 ]
 
-OMOMO_DATASET_PATH = "~/Datasets/OMOMO/retargeted"
+OMOMO_DATASET_PATH = "~/Datasets/OMOMO/retargeted_omniretarget_instinctmj_torso_v10_object_xy_align_foot_lock"
 
 MESH_FILE_PATHS = {
     "floorlamp": "~/Datasets/OMOMO/data/captured_objects/floorlamp_cleaned_simplified.obj",
@@ -292,6 +292,7 @@ class G1PerceptiveHoiShadowingEnvCfg_PLAY(G1PerceptiveHoiShadowingEnvCfg):
         # self.events.reset_robot.params["randomize_pose_range"]["roll"] = (0.0, 0.6)
 
         # remove some terimation terms
+        self.sim.nconmax = 128
         self.terminations["base_pos_too_far"] = None
         self.terminations["base_pg_too_far"] = None
         self.terminations["link_pos_too_far"] = None

--- a/src/instinct_mj/tasks/shadowing/perceptive_hoi/perceptive_env_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive_hoi/perceptive_env_cfg.py
@@ -165,9 +165,8 @@ def _make_hoi_base_sensors(include_height_scanner: bool = True) -> list[SensorCf
 
     Contact semantics differ from the perceptive task: there is NO secondary
     match, so "any contact with a robot body counts" (terrain + objects + self).
-    This matches IsaacLab's ContactSensor(prim_path="Robot/.*") net-force
-    semantics, which the shared undesired_contacts / illegal_reset_contact terms
-    rely on.
+    This preserves the source task's whole-robot net-force semantics, which the
+    shared undesired_contacts / illegal_reset_contact terms rely on.
     """
     sensor_list: list[SensorCfg] = [
         ContactSensorCfg(
@@ -175,7 +174,7 @@ def _make_hoi_base_sensors(include_height_scanner: bool = True) -> list[SensorCf
             primary=ContactMatch(mode="body", pattern=".*", entity="robot"),
             # No secondary on purpose (see docstring).
             fields=("found", "force"),
-            reduce="maxforce",
+            reduce="netforce",
             history_length=3,
             track_air_time=True,
         )
@@ -546,7 +545,7 @@ def make_hoi_events() -> dict[str, EventTermCfg]:
 
     Domain-randomization events mirror the perceptive task. HOI replaces
     'match_motion_ref_with_scene' (motion-matched terrain) with rigid-object
-    reference reset/update events, matching IsaacLab's perceptive_hoi config.
+    reference reset/update events, matching the source perceptive_hoi config.
     """
     return {
         # domain rand
@@ -859,7 +858,7 @@ class PerceptiveHoiShadowingEnvCfg(InstinctLabRLEnvCfg):
     commands: dict = field(default_factory=make_hoi_commands)
     actions: dict = field(default_factory=make_hoi_actions)
     observations: dict = field(default_factory=make_hoi_observations)
-    rewards: dict = field(default_factory=make_hoi_rewards)
+    rewards: dict = field(default_factory=lambda: {"rewards": make_hoi_rewards()})
     events: dict = field(default_factory=make_hoi_events)
     curriculum: dict = field(default_factory=make_hoi_curriculum)
     terminations: dict = field(default_factory=make_hoi_terminations)

--- a/src/instinct_mj/tasks/shadowing/perceptive_hoi/perceptive_env_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/perceptive_hoi/perceptive_env_cfg.py
@@ -614,7 +614,7 @@ def make_hoi_events() -> dict[str, EventTermCfg]:
             },
         ),
         "randomize_rigid_body_mass": EventTermCfg(
-            func=mdp.dr.body_mass,
+            func=mdp.dr.pseudo_inertia,
             mode="startup",
             params={
                 "asset_cfg": SceneEntityCfg(
@@ -627,9 +627,8 @@ def make_hoi_events() -> dict[str, EventTermCfg]:
                         "right_wrist.*",
                     ],
                 ),
-                "ranges": (0.8, 1.2),
-                "operation": "scale",
-                "distribution": "uniform",
+                "alpha_range": (0.5 * math.log(0.8), 0.5 * math.log(1.2)),
+                "distribution": instinct_mdp.uniform_mass_scale_to_alpha,
             },
         ),
         "reset_robot": EventTermCfg(

--- a/src/instinct_mj/tasks/shadowing/whole_body/config/g1/plane_shadowing_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/whole_body/config/g1/plane_shadowing_cfg.py
@@ -11,7 +11,6 @@ from copy import deepcopy
 import mjlab.envs.mdp as mdp
 import mujoco
 import yaml
-from mjlab.envs import ManagerBasedRlEnvCfg
 from mjlab.managers import (
     CurriculumTermCfg,
     EventTermCfg,
@@ -31,7 +30,6 @@ from mjlab.viewer.viewer_config import ViewerConfig
 import instinct_mj.envs.mdp as instinct_mdp
 import instinct_mj.tasks.shadowing.whole_body.shadowing_env_cfg as shadowing_cfg
 from instinct_mj.assets.unitree_g1 import G1_29DOF_TORSOBASE_POPSICLE_CFG, beyondmimic_action_scale
-from instinct_mj.envs.manager_based_rl_env_cfg import InstinctLabRLEnvCfg
 from instinct_mj.monitors import (
     MonitorTermCfg,
     MotionReferenceMonitorTerm,
@@ -268,9 +266,11 @@ motion_reference_cfg = MotionReferenceManagerCfg(
             # path = os.path.expanduser("~/your/path/to/AMASS_SMPLX-NG_GMR_29dof_g1_torsoBase_retargetted_20250901_instinctnpz")
             # path = _path_
             # NOTE: Change this to the active local whole-body shadowing dataset root.
-            path=os.path.expanduser("~/Xyk/Datasets/lafan1_gmr_unitree_g1_instinct"),
+            path=os.path.expanduser(
+                "~/Xyk/Datasets/NoKov-Marslab-Motions-instinctnpz/20251016_diveroll4_single"
+            ),
             retargetting_func=None,
-            filtered_motion_selection_filepath=f"/tmp/{MOTION_NAME}.yaml",
+            filtered_motion_selection_filepath=None,
             motion_start_from_middle_range=[0.0, 0.8],
             motion_start_height_offset=0.0,
             ensure_link_below_zero_ground=False,
@@ -688,7 +688,7 @@ def _monitors_cfg() -> dict[str, MonitorTermCfg]:
     }
 
 
-def g1_plane_shadowing_env_cfg(*, play: bool = False) -> ManagerBasedRlEnvCfg:
+def g1_plane_shadowing_env_cfg(*, play: bool = False) -> shadowing_cfg.ShadowingEnvCfg:
     active_motion_reference_cfg = deepcopy(motion_reference_cfg_play if play else motion_reference_cfg)
     entities = {
         "robot": deepcopy(G1_CFG),
@@ -733,12 +733,12 @@ def g1_plane_shadowing_env_cfg(*, play: bool = False) -> ManagerBasedRlEnvCfg:
         spec_fn=_edit_shadowing_scene_spec,
     )
 
-    cfg = InstinctLabRLEnvCfg(
+    cfg = shadowing_cfg.ShadowingEnvCfg(
         scene=scene,
         actions=_actions_cfg(),
         observations=_observations_cfg(link_of_interests=list(active_motion_reference_cfg.link_of_interests)),
         commands=_commands_cfg(),
-        rewards=deepcopy(shadowing_cfg.shadowing_rewards_terms()),
+        rewards={"rewards": deepcopy(shadowing_cfg.shadowing_rewards_terms())},
         events=_events_cfg(),
         curriculum=_curriculum_cfg(),
         terminations=_terminations_cfg(),
@@ -902,13 +902,13 @@ def g1_plane_shadowing_env_cfg(*, play: bool = False) -> ManagerBasedRlEnvCfg:
     return cfg
 
 
-def G1PlaneShadowingEnvCfg() -> ManagerBasedRlEnvCfg:
+def G1PlaneShadowingEnvCfg() -> shadowing_cfg.ShadowingEnvCfg:
     """Return the train env config."""
 
     return g1_plane_shadowing_env_cfg(play=False)
 
 
-def G1PlaneShadowingEnvCfg_PLAY() -> ManagerBasedRlEnvCfg:
+def G1PlaneShadowingEnvCfg_PLAY() -> shadowing_cfg.ShadowingEnvCfg:
     """Return the play env config."""
 
     return g1_plane_shadowing_env_cfg(play=True)

--- a/src/instinct_mj/tasks/shadowing/whole_body/shadowing_env_cfg.py
+++ b/src/instinct_mj/tasks/shadowing/whole_body/shadowing_env_cfg.py
@@ -22,7 +22,6 @@ from mjlab.utils.spec_config import MaterialCfg, TextureCfg
 import instinct_mj.envs.mdp as instinct_mdp
 import instinct_mj.tasks.shadowing.mdp as shadowing_mdp
 from instinct_mj.envs.manager_based_rl_env_cfg import InstinctLabRLEnvCfg
-from instinct_mj.managers import MultiRewardCfg
 from instinct_mj.monitors import (
     BodyStatMonitorTerm,
     JointStatMonitorTerm,
@@ -651,7 +650,7 @@ class ShadowingEnvCfg(InstinctLabRLEnvCfg):
     commands: dict = field(default_factory=make_commands)
     actions: dict = field(default_factory=make_actions)
     observations: dict = field(default_factory=make_observations)
-    rewards: dict = field(default_factory=shadowing_rewards_terms)
+    rewards: dict = field(default_factory=lambda: {"rewards": shadowing_rewards_terms()})
     events: dict = field(default_factory=make_events)
     curriculum: dict = field(default_factory=make_curriculum)
     terminations: dict = field(default_factory=make_terminations)

--- a/src/instinct_mj/terrains/trimesh/mesh_terrains.py
+++ b/src/instinct_mj/terrains/trimesh/mesh_terrains.py
@@ -118,6 +118,8 @@ def _coacd_cache_key(
         int(stat_info.st_mtime_ns),
         float(cfg.size[0]),
         float(cfg.size[1]),
+        bool(cfg.crop_to_size),
+        bool(cfg.use_input_origin_frame),
         float(cfg.collision_coacd_threshold),
         int(cfg.collision_coacd_max_convex_hull),
         str(cfg.collision_coacd_preprocess_mode),
@@ -203,24 +205,21 @@ def _compute_motion_matched_border_height(
     )
     border_verts_z = verts[border_mask][:, 2]
 
-    if len(border_verts_z) == 0:
-        # No vertices at cfg.size boundary — mesh is smaller than cfg.size.
-        # Fall back to 0.0, matching original InstinctLab behavior for these terrains.
-        # These STL meshes were recorded with the walkable floor at z≈0 by convention,
-        # so no z-shift is needed.  Using AABB edges as fallback is unsafe because for
-        # staircase/ramp terrains the AABB edges sample obstacle tops (z=0.6–0.7 m),
-        # which would incorrectly sink the entire tile by that amount.
-        border_height = 0.0
-        print(
-            f"[TerrainImporter] Terrain {terrain_file} has no border verts at cfg.size edges; "
-            "using border_height=0.0 (floor assumed at z≈0)."
-        )
-    else:
+    if len(border_verts_z) > 0:
         border_height = float(np.mean(border_verts_z))
-        if np.isnan(border_height):
-            # Unexpected — empty slice mean; treat as 0.
-            print(f"Warning: Terrain {terrain_file} does not have a valid border height. Using 0 as the border height.")
-            border_height = 0.0
+        if not np.isnan(border_height):
+            return border_height
+
+    # No vertices at cfg.size boundary — mesh may be smaller than cfg.size.
+    # These STL meshes are often recorded with the walkable floor at z≈0 by convention,
+    # but the current InstinctLab source uses a low-percentile estimate when input-frame
+    # preservation is disabled. Using AABB edges directly is unsafe because staircase/ramp
+    # edges may sample obstacle tops instead of the floor.
+    border_height = float(np.percentile(terrain_mesh.vertices[:, 2], 10.0))
+    print(
+        f"Warning: Terrain {terrain_file} does not have valid border vertices at cfg.size edges. "
+        f"Using z-percentile floor estimate {border_height:.4f} as border height."
+    )
     return border_height
 
 
@@ -228,29 +227,52 @@ def _load_motion_matched_terrain_mesh(
     terrain_abspath: str,
     terrain_file: str,
     size: tuple[float, float],
+    crop_to_size: bool,
+    use_input_origin_frame: bool,
 ) -> tuple[trimesh.Trimesh, float]:
     """Load, crop, and align one terrain mesh to generator convention."""
     terrain_mesh = trimesh.load(terrain_abspath, force="mesh")
+    border_height_reference_mesh = terrain_mesh
 
     # crop terrain mesh by cfg.size
     # This does not change the terrain origin.
-    terrain_mesh = crop_terrain_mesh_aabb(
-        terrain_mesh,
-        x_max=size[0] / 2,
-        x_min=-size[0] / 2,
-        y_max=size[1] / 2,
-        y_min=-size[1] / 2,
-    )
+    if crop_to_size:
+        terrain_mesh = crop_terrain_mesh_aabb(
+            terrain_mesh,
+            x_max=size[0] / 2,
+            x_min=-size[0] / 2,
+            y_max=size[1] / 2,
+            y_min=-size[1] / 2,
+        )
+        border_height_reference_mesh = terrain_mesh
+    else:
+        border_height_reference_mesh = crop_terrain_mesh_aabb(
+            terrain_mesh.copy(),
+            x_max=size[0] / 2,
+            x_min=-size[0] / 2,
+            y_max=size[1] / 2,
+            y_min=-size[1] / 2,
+        )
+        if len(border_height_reference_mesh.vertices) == 0:
+            print(
+                f"Warning: Terrain {terrain_file} has empty reference crop for border height estimation. "
+                "Falling back to the full mesh."
+            )
+            border_height_reference_mesh = terrain_mesh
+
     # Normalize mesh winding/normals before CoACD to reduce manifold-orientation artifacts.
     terrain_mesh.remove_unreferenced_vertices()
     trimesh.repair.fix_winding(terrain_mesh)
     trimesh.repair.fix_normals(terrain_mesh, multibody=True)
 
-    border_height = _compute_motion_matched_border_height(
-        terrain_mesh=terrain_mesh,
-        size=size,
-        terrain_file=terrain_file,
-    )
+    if use_input_origin_frame:
+        border_height = 0.0
+    else:
+        border_height = _compute_motion_matched_border_height(
+            terrain_mesh=border_height_reference_mesh,
+            size=size,
+            terrain_file=terrain_file,
+        )
 
     # To follow the terrain_generator convention, we move the terrain mesh to (size[0]/2, size[1]/2, -border_height).
     move_terrain_transform = np.eye(4)
@@ -414,14 +436,26 @@ def _run_coacd_decomposition(
 
 
 def _coacd_prewarm_worker(
-    job: tuple[str, str, tuple[float, float], dict, tuple, str, str],
+    job: tuple[str, str, tuple[float, float], bool, bool, dict, tuple, str, str],
 ) -> tuple[str, str, int]:
     """Worker job for CoACD cache prewarm."""
-    terrain_file, terrain_abspath, size, coacd_kwargs, cache_key, coacd_log_level, cache_path = job
+    (
+        terrain_file,
+        terrain_abspath,
+        size,
+        crop_to_size,
+        use_input_origin_frame,
+        coacd_kwargs,
+        cache_key,
+        coacd_log_level,
+        cache_path,
+    ) = job
     terrain_mesh, _ = _load_motion_matched_terrain_mesh(
         terrain_abspath=terrain_abspath,
         terrain_file=terrain_file,
         size=size,
+        crop_to_size=crop_to_size,
+        use_input_origin_frame=use_input_origin_frame,
     )
     parts_arrays = _run_coacd_decomposition(
         terrain_mesh=terrain_mesh,
@@ -467,6 +501,8 @@ def _prewarm_coacd_disk_cache(
         os.path.abspath(cfg.metadata_yaml),
         float(cfg.size[0]),
         float(cfg.size[1]),
+        bool(cfg.crop_to_size),
+        bool(cfg.use_input_origin_frame),
         float(cfg.collision_coacd_threshold),
         int(cfg.collision_coacd_max_convex_hull),
         str(cfg.collision_coacd_preprocess_mode),
@@ -530,6 +566,8 @@ def _prewarm_coacd_disk_cache(
                 terrain_abspath=terrain_abspath,
                 terrain_file=terrain_file,
                 size=size,
+                crop_to_size=bool(cfg.crop_to_size),
+                use_input_origin_frame=bool(cfg.use_input_origin_frame),
             )
             parts_arrays = _run_coacd_decomposition(
                 terrain_mesh=terrain_mesh,
@@ -548,6 +586,8 @@ def _prewarm_coacd_disk_cache(
                 terrain_file,
                 terrain_abspath,
                 size,
+                bool(cfg.crop_to_size),
+                bool(cfg.use_input_origin_frame),
                 coacd_kwargs,
                 cache_key,
                 coacd_log_level,
@@ -1541,6 +1581,8 @@ def motion_matched_terrain(
         terrain_abspath=terrain_abspath,
         terrain_file=terrain_file,
         size=terrain_size,
+        crop_to_size=bool(cfg.crop_to_size),
+        use_input_origin_frame=bool(cfg.use_input_origin_frame),
     )
     origin = np.array([cfg.size[0] / 2, cfg.size[1] / 2, -border_height])
 

--- a/src/instinct_mj/terrains/trimesh/mesh_terrains_cfg.py
+++ b/src/instinct_mj/terrains/trimesh/mesh_terrains_cfg.py
@@ -124,6 +124,12 @@ class MotionMatchedTerrainCfg(SubTerrainBaseCfg):
 
     """
 
+    crop_to_size: bool = True
+    """Whether to crop the source terrain mesh to ``cfg.size`` before importing it."""
+
+    use_input_origin_frame: bool = False
+    """Whether to preserve the input terrain/motion z-frame instead of estimating border height."""
+
     collision_hfield: bool = False
     """If True, use a derived MuJoCo hfield for collision while keeping mesh for rendering.
 

--- a/uv.lock
+++ b/uv.lock
@@ -637,6 +637,7 @@ dependencies = [
     { name = "regex", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "shapely", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tyro", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
@@ -662,6 +663,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "regex", specifier = ">=2024.0.0" },
     { name = "scikit-learn" },
+    { name = "shapely", specifier = ">=2.0" },
     { name = "tyro", specifier = ">=1.0.1" },
     { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.14.0", index = "https://pypi.nvidia.com/" },
     { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.14.0" },
@@ -2219,6 +2221,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
+]
+
+[[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8a/7ebc947080442edd614ceebe0ce2cdbd00c25e832c240e1d1de61d0e6b38/shapely-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eba6710407f1daa8e7602c347dfc94adc02205ec27ed956346190d66579eb9ea", size = 1629196, upload-time = "2025-09-24T13:50:03.447Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8a/0ab1f7433a2a85d9e9aea5b1fbb333f3b09b309e7817309250b4b7b2cc7a/shapely-2.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e38a190442aacc67ff9f75ce60aec04893041f16f97d242209106d502486a142", size = 3058666, upload-time = "2025-09-24T13:50:06.872Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/e92f3035ba43e53959007f928315a68fbcf2eeb4e5ededb6f0dc7ff1ecc3/shapely-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f6f6cd5819c50d9bcf921882784586aab34a4bd53e7553e175dece6db513a6f0", size = 4129260, upload-time = "2025-09-24T13:50:11.183Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ce/28fab8c772ce5db23a0d86bf0adaee0c4c79d5ad1db766055fa3dab442e2/shapely-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:16a9c722ba774cf50b5d4541242b4cce05aafd44a015290c82ba8a16931ff63d", size = 1626039, upload-time = "2025-09-24T13:50:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/13/02/58b0b8d9c17c93ab6340edd8b7308c0c5a5b81f94ce65705819b7416dba5/shapely-2.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:136ab87b17e733e22f0961504d05e77e7be8c9b5a8184f685b4a91a84efe3c26", size = 3110842, upload-time = "2025-09-24T13:50:21.77Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d4/9b2a9fe6039f9e42ccf2cb3e84f219fd8364b0c3b8e7bbc857b5fbe9c14c/shapely-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ddc759f72b5b2b0f54a7e7cde44acef680a55019eb52ac63a7af2cf17cb9cd2", size = 4178586, upload-time = "2025-09-24T13:50:25.443Z" },
+    { url = "https://files.pythonhosted.org/packages/86/07/59dee0bc4b913b7ab59ab1086225baca5b8f19865e6101db9ebb7243e132/shapely-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba4d1333cc0bc94381d6d4308d2e4e008e0bd128bdcff5573199742ee3634359", size = 1643556, upload-time = "2025-09-24T13:50:32.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e7d4d7ad262a48bb44277ca12c7c78cb1b0f56b32c10734ec9a1d30c0b0c54b", size = 3099844, upload-time = "2025-09-24T13:50:35.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/704c7292f7014c7e74ec84eddb7b109e1fbae74a16deae9c1504b1d15565/shapely-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:980c777c612514c0cf99bc8a9de6d286f5e186dcaf9091252fcd444e5638193d", size = 4152714, upload-time = "2025-09-24T13:50:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/0bee5a830d209adcd3a01f2d4b70e587cdd9fd7380d5198c064091005af8/shapely-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8cff473e81017594d20ec55d86b54bc635544897e13a7cfc12e36909c5309a2a", size = 1642887, upload-time = "2025-09-24T13:50:46.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ed1a5bbfb386ee8332713bf7508bc24e32d24b74fc9a7b9f8529a55db9f4ee6", size = 3082855, upload-time = "2025-09-24T13:50:50.037Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/04/167f096386120f692cc4ca02f75a17b961858997a95e67a3cb6a7bbd6b53/shapely-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc3487447a43d42adcdf52d7ac73804f2312cbfa5d433a7d2c506dcab0033dfd", size = 4142851, upload-time = "2025-09-24T13:50:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/dce001c1984052970ff60eb4727164892fb2d08052c575042a47f5a9e88f/shapely-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b", size = 1642802, upload-time = "2025-09-24T13:50:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/18/7519a25db21847b525696883ddc8e6a0ecaa36159ea88e0fef11466384d0/shapely-2.1.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19efa3611eef966e776183e338b2d7ea43569ae99ab34f8d17c2c054d3205cc0", size = 3095223, upload-time = "2025-09-24T13:51:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -20,9 +20,6 @@ required-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 
-[manifest]
-overrides = [{ name = "mujoco", specifier = ">=3.8.0.dev0", index = "https://py.mujoco.org/" }]
-
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -641,7 +638,8 @@ dependencies = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tyro", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "warp-lang", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
 ]
 
 [package.metadata]
@@ -651,9 +649,9 @@ requires-dist = [
     { name = "instinct-rl", git = "https://github.com/project-instinct/instinct_rl.git" },
     { name = "mediapy", specifier = ">=1.2.0" },
     { name = "mjlab", editable = "../mjlab" },
-    { name = "mujoco", specifier = "~=3.8.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=88b55fc2696960b927bc12584994bb8412b36558" },
-    { name = "numpy", specifier = ">=1.24" },
+    { name = "mujoco", specifier = "~=3.10.0" },
+    { name = "mujoco-warp", specifier = "~=3.10.0,>=3.10.0.1" },
+    { name = "numpy", specifier = ">=1.24,<2.5" },
     { name = "numpy-quaternion" },
     { name = "onnxruntime" },
     { name = "opencv-python", specifier = ">=4.8" },
@@ -978,7 +976,7 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "../mjlab" }
 dependencies = [
     { name = "imageio-ffmpeg", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -986,6 +984,8 @@ dependencies = [
     { name = "mjviser", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mujoco", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mujoco-warp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "onnxscript", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "prettytable", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rsl-rl-lib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1000,19 +1000,21 @@ dependencies = [
     { name = "tyro", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "viser", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wandb", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "warp-lang", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy", specifier = ">=1.2.6" },
-    { name = "mjviser", git = "https://github.com/mujocolab/mjviser?rev=1bdfd6fe79066b847a5f430000fcfbb53ec31a6f" },
-    { name = "mujoco", specifier = "~=3.8.0", index = "https://py.mujoco.org/" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp?rev=88b55fc2696960b927bc12584994bb8412b36558" },
+    { name = "mjviser", specifier = ">=0.0.14" },
+    { name = "mujoco", specifier = "~=3.10.0" },
+    { name = "mujoco-warp", specifier = "~=3.10.0,>=3.10.0.1" },
+    { name = "numpy", specifier = "<2.5" },
     { name = "onnxscript", specifier = ">=0.5.4" },
     { name = "prettytable" },
-    { name = "rsl-rl-lib", specifier = "==5.2.0" },
+    { name = "rsl-rl-lib", specifier = "==5.4.0" },
     { name = "scipy", specifier = ">=1.15" },
     { name = "tensorboard", specifier = ">=2.20.0" },
     { name = "tensordict" },
@@ -1027,8 +1029,8 @@ requires-dist = [
     { name = "tyro", specifier = ">=1.0.1" },
     { name = "viser", specifier = ">=1.0.27" },
     { name = "wandb", specifier = ">=0.22.3" },
-    { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.12.0", index = "https://pypi.nvidia.com/" },
-    { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.12.0" },
+    { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.14.0", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.14.0" },
 ]
 provides-extras = ["cu128", "cpu"]
 
@@ -1060,8 +1062,8 @@ docs = [
 
 [[package]]
 name = "mjviser"
-version = "0.0.13"
-source = { git = "https://github.com/mujocolab/mjviser?rev=1bdfd6fe79066b847a5f430000fcfbb53ec31a6f#1bdfd6fe79066b847a5f430000fcfbb53ec31a6f" }
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mujoco", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1069,6 +1071,10 @@ dependencies = [
     { name = "pillow", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "trimesh", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "viser", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/eef89b279fb1811b5f120a99ac9284c32ff2ca4fad5e6f5c93035f72ba9a/mjviser-0.0.14.tar.gz", hash = "sha256:ebde2203dab89959a13ae549b4d3e5e5cf9eb69de11a1a2fd759cbe8f8c641f3", size = 29576, upload-time = "2026-05-07T03:35:13.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/c2/4534d678ad1b3f7dee6fd83110112800287be21ba007d988abb9ddc8e0ac/mjviser-0.0.14-py3-none-any.whl", hash = "sha256:4b09f8e90506fc4a71d76fc628872147157947e9292428213ab78cfe137c9a26", size = 32296, upload-time = "2026-05-07T03:35:14.252Z" },
 ]
 
 [[package]]
@@ -1124,8 +1130,8 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.10.0.dev925204136"
-source = { registry = "https://py.mujoco.org/" }
+version = "3.10.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "etils", extra = ["epath"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1134,28 +1140,34 @@ dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyopengl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/3b/c76837b7fdb007f7605ff783689a0bd23a5a49b065928bec2f1fa7ea3d67/mujoco-3.10.0.tar.gz", hash = "sha256:c9e8d5d87d82204ed5bccc87d843c0a53e75aaf381de2938ec46d04f1ac6e24e", size = 1094987, upload-time = "2026-06-22T17:40:59.904Z" }
 wheels = [
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp310-cp310-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp311-cp311-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp312-cp312-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp313-cp313-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.10.0.dev925204136-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://files.pythonhosted.org/packages/09/be/3d9a1ecfe3501a84ece0d5824ff67a0933337650fb48b26c8db0b43de0cd/mujoco-3.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c8e4688d87b85be27dfcfdf957f05f1450a99131f9f8b1818613a2e4fd8d7321", size = 19324219, upload-time = "2026-06-22T17:39:49.666Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3c/e3768418794c4450c6bef971eaa2314e1fac7d46abc6968b6722b0b654a0/mujoco-3.10.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47a89c371cc171a38eb6c03172aff2f905e54c1261d87b3575a9d77fe3a29a55", size = 20763444, upload-time = "2026-06-22T17:39:56.559Z" },
+    { url = "https://files.pythonhosted.org/packages/41/69/4c55c05fe602d72be5526d911e6802de1e67ad70c9301f556eef1d78a4bb/mujoco-3.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b812e0e36e8b2dde8ce4ad9b25e189b658b9c94f5e798aa64783261abb88321", size = 19348907, upload-time = "2026-06-22T17:40:04.634Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/07/a37fc7fa55d38e9225884b80c3d241e669357e83f7e23f80b8860a7e14cd/mujoco-3.10.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5489e18a8dd09da2dd71d28563e17889a2e5a0ad07943ebcaa1446d6c4d4e1dd", size = 20789312, upload-time = "2026-06-22T17:40:10.656Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7d/ebe5342c136de27e0c430ba781f829df2cd66c00ed22627c1964fbd5d7fe/mujoco-3.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4d35e9d0b13ff9ad3196294a7dac363f1d0cdaa988832d0b687d42d98f4ee29", size = 19380823, upload-time = "2026-06-22T17:40:19.211Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/11/c69199e4123935f98068ab6ab6b35955b4de0f6a91d3f9883805a5789394/mujoco-3.10.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:966d12f88e77e2b188e7530667b519d6963b9b906cff83bab534e5e4279325a0", size = 20904309, upload-time = "2026-06-22T17:40:25.861Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ea/15dfc7cc10f44f46286a0634499f3a63e03269adb4788903f3751e964be0/mujoco-3.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db794d8b8a64e3bb6a0f226a9200293a4890f490c93411fcc531a145f373521b", size = 19381290, upload-time = "2026-06-22T17:40:34.251Z" },
+    { url = "https://files.pythonhosted.org/packages/52/49/f6f0c7c54c646adda647aa7495bdc69572419480c37d5cd0bee132ebacd6/mujoco-3.10.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0a5725cc9c9a4da1d5f2b8314ad6d39007e09430ac00aa8d023995ce1f2a3e9", size = 20904596, upload-time = "2026-06-22T17:40:40.423Z" },
 ]
 
 [[package]]
 name = "mujoco-warp"
-version = "3.8.0.2"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=88b55fc2696960b927bc12584994bb8412b36558#88b55fc2696960b927bc12584994bb8412b36558" }
+version = "3.10.0.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "etils", extra = ["epath"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mujoco", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "warp-lang", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "warp-lang", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/e5/37d982ba8bdbad8455fb74da827aa4e8ea1b984db66171d4b66c458da985/mujoco_warp-3.10.0.1.tar.gz", hash = "sha256:adca3e740112bca1aaaa732556aad0f36fb3dea99f86abd22ee1232dc5e2b28d", size = 2046299, upload-time = "2026-06-26T15:59:41.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/32/9adafac9cf8133cebe5825b306be01ab9209ab0fb5a057cb29e4f5b23bd5/mujoco_warp-3.10.0.1-py3-none-any.whl", hash = "sha256:7a5871a5522796fa36ec5614dc214a180d4fc7de861e413ee1559d2cc4ec79f9", size = 2123960, upload-time = "2026-06-26T15:59:39.77Z" },
 ]
 
 [[package]]
@@ -2032,7 +2044,7 @@ wheels = [
 
 [[package]]
 name = "rsl-rl-lib"
-version = "5.2.0"
+version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitpython", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2040,13 +2052,14 @@ dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "onnx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "onnxscript", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tensorboard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tensordict", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "torch", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "torchvision", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/a8/fb9aae0573a83dd510e228085f5e6ff9076a91f2bff6699270f07d31854c/rsl_rl_lib-5.2.0.tar.gz", hash = "sha256:cbb4eee96af9574495208381115d45d68ad1c0403710a2bc6512a2ee5bf57124", size = 60558, upload-time = "2026-04-23T12:40:54.259Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/51/2d4c95b3642c0f659fbcddcd17fa0401903733250fa382f51f9b913bb85f/rsl_rl_lib-5.4.0.tar.gz", hash = "sha256:e1aa5cd5771f2d9a9e7a7ba5456b942ab588410cfd397b3c63e32d00a0744f0d", size = 65902, upload-time = "2026-05-27T10:42:39.656Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/3a/3e8f39049cc5a8994bfdb2dd09d727f90a2781b9755adf59e49fa509500e/rsl_rl_lib-5.2.0-py3-none-any.whl", hash = "sha256:fc767059f329a184527dd10766c3382354f6deca4b049f23febc8140c3dc6029", size = 86451, upload-time = "2026-04-23T12:40:52.762Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/dd/6797be77ce0cc12881f29cd9363b791f15276fde6a136a73443b6b6c2ce3/rsl_rl_lib-5.4.0-py3-none-any.whl", hash = "sha256:b30a0e59dac0ef7236f8f793c9bedfa8f2b8f8d29c2965140feeb1439153ebab", size = 92871, upload-time = "2026-05-27T10:42:38.415Z" },
 ]
 
 [[package]]
@@ -2628,13 +2641,36 @@ wheels = [
 name = "warp-lang"
 version = "1.14.0"
 source = { registry = "https://pypi.nvidia.com/" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:12656050545cc77bf9b9b155399496c1a6279b5b6c59e407507d6858a2beb4a2" },
     { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:70cd127d0e9109417099649fedf9d00f39f1307ccb7a6e9fb87661337868d7de" },
+]
+
+[[package]]
+name = "warp-lang"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/0f/28ba3c563a87adb85884fb59f5f281446f99a338c907e2b3f0b9f2f4a76c/warp_lang-1.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:12656050545cc77bf9b9b155399496c1a6279b5b6c59e407507d6858a2beb4a2", size = 24755239, upload-time = "2026-06-01T15:15:53.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update the mjlab 1.5 baseline and use dataclass environment configs with dictionary-based managers
- align locomotion, parkour, BeyondMimic, WholeBody, Perceptive, VAE, and HOI task configuration semantics
- fix grouped reward loading, monitoring, runner config export, motion-matched terrain handling, and package assets
- add OMOMO alignment and HOI playback utilities

## Why

Several migrated task configs had diverged from the current InstinctLab behavior or relied on compatibility-style reward conversion. This change makes the configuration shape explicit, restores the intended active presets, and keeps the runtime interfaces aligned with mjlab.

## Impact

All registered tasks now construct concrete InstinctMJ environment configs with dictionary managers and grouped rewards. Parkour keeps its existing training terrain parameters, uses wall-free PLAY terrain, and retains the Perlin hfield dense-box implementation. HOI uses nconmax=128.

## Validation

- git diff --check
- python -m compileall -q src/instinct_mj
- python -m unittest discover -s tests -v (6 tests)
- Locomotion, Parkour, and Perceptive single-environment reset/step smoke tests
- wheel and source distribution asset checks